### PR TITLE
Add targeted diagnostics logging across network manager, routing, and forwarding paths

### DIFF
--- a/components/lora_network_layer/src/forwarding_queue.cpp
+++ b/components/lora_network_layer/src/forwarding_queue.cpp
@@ -1,4 +1,5 @@
 #include "forwarding_queue.h"
+#include "esp_log.h"
 #include "geo_utils.h"
 #include <cstring>
 #include <algorithm>
@@ -6,6 +7,8 @@
 #ifndef CONFIG_NET_BETWEENNESS_THRESHOLD_M
 #define CONFIG_NET_BETWEENNESS_THRESHOLD_M 100
 #endif
+
+static const char* TAG = "forwarding_queue";
 
 ForwardingQueue::ForwardingQueue(size_t capacity, ILinkLayer& link,
                                  const ILocationProvider& loc)
@@ -56,6 +59,8 @@ bool ForwardingQueue::enqueue(const NetworkHeader& hdr, const uint8_t* payload,
     }
 
     if (!slot) {
+        ESP_LOGW(TAG, "Forwarding queue full, drop msg_id=0x%08lx",
+                 static_cast<unsigned long>(hdr.message_id));
         xSemaphoreGive(mutex_);
         return false;
     }
@@ -143,5 +148,9 @@ void ForwardingQueue::fireEntry(PendingRelay& entry)
     std::memcpy(buf + sizeof(NetworkHeader), entry.payload, entry.payload_len);
     size_t total = sizeof(NetworkHeader) + entry.payload_len;
 
+    ESP_LOGD(TAG, "Relay TX msg_id=0x%08lx bytes=%zu hops_remaining=%u",
+             static_cast<unsigned long>(entry.hdr.message_id),
+             total,
+             entry.hdr.hops_remaining);
     link_.send(BROADCAST_ADDR, buf, total);
 }

--- a/components/lora_network_layer/src/network_manager.cpp
+++ b/components/lora_network_layer/src/network_manager.cpp
@@ -1,4 +1,5 @@
 #include "network_manager.h"
+#include "esp_log.h"
 #include <cstring>
 
 #ifndef CONFIG_NET_DUPLICATE_CACHE_SIZE
@@ -15,6 +16,7 @@ static constexpr UBaseType_t kRxTaskPrio  = 5;
 static constexpr UBaseType_t kFwdTaskPrio = 4;
 static constexpr uint32_t   kRxTaskStack  = 4096;
 static constexpr uint32_t   kFwdTaskStack = 4096;
+static const char* TAG = "network_manager";
 
 NetworkManager::NetworkManager(ILinkLayer& link, ILocationProvider& loc,
                                const NetworkConfig& cfg)
@@ -34,9 +36,18 @@ NetworkManager::NetworkManager(ILinkLayer& link, ILocationProvider& loc,
 
 NetworkManager::~NetworkManager()
 {
-    if (rx_task_handle_)  vTaskDelete(rx_task_handle_);
-    if (fwd_task_handle_) vTaskDelete(fwd_task_handle_);
-    if (rx_queue_)        vQueueDelete(rx_queue_);
+    if (rx_task_handle_) {
+        ESP_LOGI(TAG, "Stopping RX task");
+        vTaskDelete(rx_task_handle_);
+    }
+    if (fwd_task_handle_) {
+        ESP_LOGI(TAG, "Stopping forwarding task");
+        vTaskDelete(fwd_task_handle_);
+    }
+    if (rx_queue_) {
+        ESP_LOGI(TAG, "Deleting RX queue");
+        vQueueDelete(rx_queue_);
+    }
 }
 
 void NetworkManager::start()
@@ -50,13 +61,17 @@ void NetworkManager::start()
         evt.len  = copy_len;
         evt.rssi = rssi;
         evt.snr  = snr;
-        xQueueSendToBack(rx_queue_, &evt, 0);  // Non-blocking
+        if (xQueueSendToBack(rx_queue_, &evt, 0) != pdTRUE) {  // Non-blocking
+            ESP_LOGW(TAG, "RX queue full, dropping frame len=%zu", copy_len);
+        }
     });
 
     xTaskCreate(rxTaskEntry, "net_rx", kRxTaskStack, this,
                 kRxTaskPrio, &rx_task_handle_);
+    ESP_LOGI(TAG, "RX task started");
     xTaskCreate(fwdTaskEntry, "net_fwd", kFwdTaskStack, this,
                 kFwdTaskPrio, &fwd_task_handle_);
+    ESP_LOGI(TAG, "Forwarding task started");
 }
 
 void NetworkManager::setAppRxCallback(AppRxCallback cb)
@@ -136,7 +151,11 @@ void NetworkManager::rxTaskLoop()
         // Run routing pipeline.
         EvalResult result = routing_.evaluate(hdr, evt.rssi, evt.snr);
 
-        if (result.verdict == Verdict::DROP) continue;
+        if (result.verdict == Verdict::DROP) {
+            ESP_LOGD(TAG, "Dropping msg_id=0x%08lx by routing verdict",
+                     static_cast<unsigned long>(hdr.message_id));
+            continue;
+        }
 
         // Deliver to application.
         if (app_cb_) {
@@ -145,7 +164,13 @@ void NetworkManager::rxTaskLoop()
 
         // Schedule relay if needed.
         if (result.verdict == Verdict::DELIVER_AND_FORWARD) {
-            fwd_queue_.enqueue(hdr, app_payload, app_len, result.holdback_ms);
+            ESP_LOGD(TAG, "Scheduling relay msg_id=0x%08lx holdback_ms=%lu",
+                     static_cast<unsigned long>(hdr.message_id),
+                     static_cast<unsigned long>(result.holdback_ms));
+            if (!fwd_queue_.enqueue(hdr, app_payload, app_len, result.holdback_ms)) {
+                ESP_LOGW(TAG, "Forwarding queue full, dropped relay msg_id=0x%08lx",
+                         static_cast<unsigned long>(hdr.message_id));
+            }
         }
     }
 }

--- a/components/lora_network_layer/src/routing_engine.cpp
+++ b/components/lora_network_layer/src/routing_engine.cpp
@@ -1,4 +1,5 @@
 #include "routing_engine.h"
+#include "esp_log.h"
 #include "geo_utils.h"
 #include <algorithm>
 #include <cmath>
@@ -18,6 +19,7 @@
 #endif
 
 static constexpr uint8_t kMaxPriorityIndex = 3;
+static const char* TAG = "routing_engine";
 
 static constexpr float kPriorityMultiplier[] = {
     0.25f,  // EMERGENCY
@@ -41,6 +43,8 @@ EvalResult RoutingEngine::evaluate(const NetworkHeader& hdr,
 {
     // 1. Duplicate check
     if (dup_filter_.isDuplicate(hdr.message_id)) {
+        ESP_LOGD(TAG, "Duplicate detected msg_id=0x%08lx, dropping",
+                 static_cast<unsigned long>(hdr.message_id));
         return {Verdict::DROP, 0};
     }
 
@@ -48,12 +52,16 @@ EvalResult RoutingEngine::evaluate(const NetworkHeader& hdr,
     uint32_t now = loc_.getTimestamp();
     if (now != 0 && hdr.timestamp != 0) {
         if (hdr.timestamp + hdr.lifetime_s < now) {
+            ESP_LOGD(TAG, "TTL expired msg_id=0x%08lx, dropping",
+                     static_cast<unsigned long>(hdr.message_id));
             return {Verdict::DROP, 0};
         }
     }
 
     // 3. Hops remaining
     if (hdr.hops_remaining == 0) {
+        ESP_LOGD(TAG, "Routing verdict DELIVER_ONLY msg_id=0x%08lx (hops exhausted)",
+                 static_cast<unsigned long>(hdr.message_id));
         return {Verdict::DELIVER_ONLY, 0};
     }
 
@@ -62,6 +70,8 @@ EvalResult RoutingEngine::evaluate(const NetworkHeader& hdr,
     float dist_from_origin = geo::haversine_m(hdr.originPoint(), my_loc);
     if (hdr.max_distance_m > 0 &&
         dist_from_origin > static_cast<float>(hdr.max_distance_m)) {
+        ESP_LOGD(TAG, "Routing verdict DELIVER_ONLY msg_id=0x%08lx (max distance exceeded)",
+                 static_cast<unsigned long>(hdr.message_id));
         return {Verdict::DELIVER_ONLY, 0};
     }
 
@@ -70,12 +80,17 @@ EvalResult RoutingEngine::evaluate(const NetworkHeader& hdr,
         if (!geo::isInsideCone(hdr.originPoint(), my_loc,
                                hdr.target_heading,
                                CONFIG_NET_DIRECTIONAL_HALF_ANGLE)) {
+            ESP_LOGD(TAG, "Routing verdict DELIVER_ONLY msg_id=0x%08lx (outside cone)",
+                     static_cast<unsigned long>(hdr.message_id));
             return {Verdict::DELIVER_ONLY, 0};
         }
     }
 
     // All checks passed — deliver and forward
     uint32_t holdback = computeHoldback(hdr, snr);
+    ESP_LOGD(TAG, "Routing verdict DELIVER_AND_FORWARD msg_id=0x%08lx holdback_ms=%lu",
+             static_cast<unsigned long>(hdr.message_id),
+             static_cast<unsigned long>(holdback));
     return {Verdict::DELIVER_AND_FORWARD, holdback};
 }
 


### PR DESCRIPTION
The network layer had no runtime diagnostics, making key packet-handling decisions opaque during operation. This change introduces focused ESP-IDF logging at critical control points: queue pressure drops, duplicate/TTL rejection, routing outcomes, relay transmission, and task lifecycle.

Logging infrastructure

Added file-scope TAG and esp_log.h usage in:
network_manager.cpp
routing_engine.cpp
forwarding_queue.cpp
Ingress + task lifecycle visibility (network_manager.cpp)

Log RX queue overflow drops in the link-layer RX callback.
Log task lifecycle events for RX/FWD task start and teardown.
Log routing-driven drops and relay scheduling outcomes (including enqueue failure due to forwarding queue pressure).
Routing decision diagnostics (routing_engine.cpp)

Log duplicate detection drops.
Log TTL expiry drops.
Log routing verdict branches:
DELIVER_ONLY (hops exhausted, max-distance exceeded, directional cone miss)
DELIVER_AND_FORWARD (with computed holdback)
Forwarding queue + relay TX diagnostics (forwarding_queue.cpp)

Log forwarding-queue full drops when no slot/eviction candidate is available.
Log relay transmission details at fire time (message id, size, remaining hops).