### PR TITLE
Issue 2: Data race on app_cb_ — not thread-safe

### DIFF
--- a/components/lora_network_layer/include/network_manager.h
+++ b/components/lora_network_layer/include/network_manager.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "network_header.h"
 #include "link_layer_interface.h"
@@ -94,6 +95,7 @@ private:
     QueueHandle_t       rx_queue_;
     TaskHandle_t        rx_task_handle_;
     TaskHandle_t        fwd_task_handle_;
+    SemaphoreHandle_t   app_cb_mutex_;
 
     AppRxCallback       app_cb_;
     std::atomic<uint8_t> seq_;   // Outgoing sequence number

--- a/components/lora_network_layer/src/network_manager.cpp
+++ b/components/lora_network_layer/src/network_manager.cpp
@@ -26,16 +26,21 @@ NetworkManager::NetworkManager(ILinkLayer& link, ILocationProvider& loc,
     , rx_queue_(nullptr)
     , rx_task_handle_(nullptr)
     , fwd_task_handle_(nullptr)
+    , app_cb_mutex_(nullptr)
     , seq_(0)
 {
     rx_queue_ = xQueueCreate(cfg.rx_queue_depth, sizeof(RxEvent));
+    app_cb_mutex_ = xSemaphoreCreateMutex();
     configASSERT(rx_queue_);
+    configASSERT(app_cb_mutex_);
 }
 
 NetworkManager::~NetworkManager()
 {
+    link_.setRxHandler(nullptr);
     if (rx_task_handle_)  vTaskDelete(rx_task_handle_);
     if (fwd_task_handle_) vTaskDelete(fwd_task_handle_);
+    if (app_cb_mutex_)    vSemaphoreDelete(app_cb_mutex_);
     if (rx_queue_)        vQueueDelete(rx_queue_);
 }
 
@@ -61,7 +66,9 @@ void NetworkManager::start()
 
 void NetworkManager::setAppRxCallback(AppRxCallback cb)
 {
+    xSemaphoreTake(app_cb_mutex_, portMAX_DELAY);
     app_cb_ = std::move(cb);
+    xSemaphoreGive(app_cb_mutex_);
 }
 
 int NetworkManager::sendMessage(Priority priority, PropagationMode mode,
@@ -138,9 +145,14 @@ void NetworkManager::rxTaskLoop()
 
         if (result.verdict == Verdict::DROP) continue;
 
-        // Deliver to application.
-        if (app_cb_) {
-            app_cb_(hdr, app_payload, app_len);
+        // Copy callback under lock, then invoke it unlocked.
+        AppRxCallback cb;
+        xSemaphoreTake(app_cb_mutex_, portMAX_DELAY);
+        cb = app_cb_;
+        xSemaphoreGive(app_cb_mutex_);
+
+        if (cb) {
+            cb(hdr, app_payload, app_len);
         }
 
         // Schedule relay if needed.


### PR DESCRIPTION
Fixed. `app_cb_` access is now synchronized so `setAppRxCallback()` and `rxTaskLoop()` cannot race on `std::function`.

### Changes made
- Added a FreeRTOS mutex for callback state:
  - network_manager.h
  - Added `#include "freertos/semphr.h"` and member `SemaphoreHandle_t app_cb_mutex_;`

- Initialized and validated the mutex:
  - network_manager.cpp
  - In constructor: `app_cb_mutex_ = xSemaphoreCreateMutex();` with `configASSERT(app_cb_mutex_);`

- Protected callback writes:
  - network_manager.cpp
  - `setAppRxCallback()` now `take -> assign -> give`.

- Protected callback reads with copy-then-call pattern:
  - network_manager.cpp
  - In `rxTaskLoop()`, it now copies `app_cb_` under lock to a local `cb`, releases lock, then invokes `cb(...)` outside the lock.

- Minor safety cleanup:
  - network_manager.cpp
  - Destructor now unregisters RX handler before teardown and deletes `app_cb_mutex_`.

### Why this resolves the UB
`std::function` is not thread-safe for concurrent read/write. The mutex ensures mutual exclusion on `app_cb_` access, and invoking outside the lock avoids holding internal synchronization during arbitrary app code.

### Note
Diagnostics show include-path/indexing issues for FreeRTOS headers in the IDE translation unit, but no code-level errors were reported in the edited header.