### PR TITLE
Add configurable task priorities and stack sizes for RX and forwarding tasks

### DIFF
--- a/components/lora_network_layer/Kconfig
+++ b/components/lora_network_layer/Kconfig
@@ -38,6 +38,30 @@ menu "LoRa Network Layer"
             Depth of the FreeRTOS queue between the link-layer callback and
             the network RX task.
 
+    config NET_RX_TASK_PRIORITY
+        int "RX task priority"
+        default 5
+        help
+            FreeRTOS priority for the network RX processing task.
+
+    config NET_FWD_TASK_PRIORITY
+        int "Forwarding task priority"
+        default 4
+        help
+            FreeRTOS priority for the forwarding-timer processing task.
+
+    config NET_RX_TASK_STACK
+        int "RX task stack size (bytes)"
+        default 4096
+        help
+            Stack size in bytes allocated to the network RX task.
+
+    config NET_FWD_TASK_STACK
+        int "Forwarding task stack size (bytes)"
+        default 4096
+        help
+            Stack size in bytes allocated to the forwarding task.
+
     config NET_DIRECTIONAL_HALF_ANGLE
         int "Directional cone half-angle (0.01 deg)"
         default 4500

--- a/components/lora_network_layer/src/network_manager.cpp
+++ b/components/lora_network_layer/src/network_manager.cpp
@@ -10,11 +10,23 @@
 #ifndef CONFIG_NET_RX_QUEUE_DEPTH
 #define CONFIG_NET_RX_QUEUE_DEPTH 8
 #endif
+#ifndef CONFIG_NET_RX_TASK_PRIORITY
+#define CONFIG_NET_RX_TASK_PRIORITY 5
+#endif
+#ifndef CONFIG_NET_FWD_TASK_PRIORITY
+#define CONFIG_NET_FWD_TASK_PRIORITY 4
+#endif
+#ifndef CONFIG_NET_RX_TASK_STACK
+#define CONFIG_NET_RX_TASK_STACK 4096
+#endif
+#ifndef CONFIG_NET_FWD_TASK_STACK
+#define CONFIG_NET_FWD_TASK_STACK 4096
+#endif
 
-static constexpr UBaseType_t kRxTaskPrio  = 5;
-static constexpr UBaseType_t kFwdTaskPrio = 4;
-static constexpr uint32_t   kRxTaskStack  = 4096;
-static constexpr uint32_t   kFwdTaskStack = 4096;
+static constexpr UBaseType_t kRxTaskPrio  = static_cast<UBaseType_t>(CONFIG_NET_RX_TASK_PRIORITY);
+static constexpr UBaseType_t kFwdTaskPrio = static_cast<UBaseType_t>(CONFIG_NET_FWD_TASK_PRIORITY);
+static constexpr uint32_t    kRxTaskStack = static_cast<uint32_t>(CONFIG_NET_RX_TASK_STACK);
+static constexpr uint32_t    kFwdTaskStack = static_cast<uint32_t>(CONFIG_NET_FWD_TASK_STACK);
 
 NetworkManager::NetworkManager(ILinkLayer& link, ILocationProvider& loc,
                                const NetworkConfig& cfg)


### PR DESCRIPTION
Introduce options to configure the FreeRTOS task priorities and stack sizes for the network RX and forwarding tasks, enhancing flexibility in task management.