### PR TITLE
Clamp holdback delay after priority multiplier

### DIFF
--- a/components/lora_network_layer/src/routing_engine.cpp
+++ b/components/lora_network_layer/src/routing_engine.cpp
@@ -96,11 +96,18 @@ uint32_t RoutingEngine::computeHoldback(const NetworkHeader& hdr,
 
     float t_min = static_cast<float>(CONFIG_NET_HOLDBACK_MIN_MS);
     float t_max = static_cast<float>(CONFIG_NET_HOLDBACK_MAX_MS);
+
     float holdback = t_min + (t_max - t_min) * combined;
 
     uint8_t pri = hdr.priority;
-    if (pri > kMaxPriorityIndex) pri = kMaxPriorityIndex;
+    if (pri > kMaxPriorityIndex) {
+        pri = kMaxPriorityIndex;
+    }
+
     holdback *= kPriorityMultiplier[pri];
+
+    // Ensure final value stays within configured bounds
+    holdback = std::clamp(holdback, t_min, t_max);
 
     return static_cast<uint32_t>(holdback);
 }


### PR DESCRIPTION
The holdback delay was computed within the configured bounds
[CONFIG_NET_HOLDBACK_MIN_MS, CONFIG_NET_HOLDBACK_MAX_MS] and then
scaled by a priority multiplier.

This could push the final value outside the configured limits:
- Emergency priority could produce values below the minimum
- Low priority could exceed the maximum

This change enforces a final std::clamp() after applying the
priority multiplier to ensure the resulting holdback delay
always respects the configured bounds.

Closes #30 