### PR TITLE
Simulation

### DIFF
--- a/components/lora_network_layer/include/forwarding_queue.h
+++ b/components/lora_network_layer/include/forwarding_queue.h
@@ -22,7 +22,7 @@ class ForwardingQueue {
 public:
     ForwardingQueue(size_t capacity, ILinkLayer& link,
                     const ILocationProvider& loc);
-    ~ForwardingQueue();
+    ~ForwardingQueue() = default;
 
     ForwardingQueue(const ForwardingQueue&) = delete;
     ForwardingQueue& operator=(const ForwardingQueue&) = delete;

--- a/components/lora_network_layer/include/network_header.h
+++ b/components/lora_network_layer/include/network_header.h
@@ -32,12 +32,19 @@ static constexpr uint8_t  NET_MSG_TYPE     = 0x10;
 /** Maximum LoRa payload size in bytes. */
 static constexpr size_t   LORA_MAX_PAYLOAD = 247;
 
+#if defined(_MSC_VER)
+#  define NET_PACKED
+#  pragma pack(push, 1)
+#else
+#  define NET_PACKED __attribute__((packed))
+#endif
+
 /**
  * 45-byte packed network header transmitted over the air.
  *
  * All multi-byte fields are little-endian (native on ESP32).
  */
-struct __attribute__((packed)) NetworkHeader {
+struct NET_PACKED NetworkHeader {
     uint32_t message_id;       // (origin_nodeId << 16) | sequence
     uint8_t  priority;         // Priority enum
     uint32_t timestamp;        // Epoch seconds (32-bit)
@@ -67,6 +74,12 @@ struct __attribute__((packed)) NetworkHeader {
     void setOriginPoint(GeoPoint p) { origin_lat = p.lat; origin_lon = p.lon; }
     void setTxPoint(GeoPoint p)     { tx_lat = p.lat; tx_lon = p.lon; }
 };
+
+#if defined(_MSC_VER)
+#  pragma pack(pop)
+#endif
+
+#undef NET_PACKED
 
 static_assert(sizeof(NetworkHeader) == 45, "NetworkHeader must be exactly 45 bytes");
 

--- a/components/lora_network_layer/src/geo_utils.cpp
+++ b/components/lora_network_layer/src/geo_utils.cpp
@@ -4,8 +4,9 @@
 
 namespace geo {
 
-static constexpr double kDegToRad = M_PI / 180.0;
-static constexpr double kRadToDeg = 180.0 / M_PI;
+static constexpr double kPi       = 3.14159265358979323846;
+static constexpr double kDegToRad = kPi / 180.0;
+static constexpr double kRadToDeg = 180.0 / kPi;
 static constexpr double kEarthR   = 6371000.0; // metres
 
 /** Convert fixed-point ×1e7 integer to radians. */

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -3,17 +3,18 @@ PROJECT_BRIEF          = "V2X LoRa multi-hop network layer for ESP-IDF"
 OUTPUT_DIRECTORY       = docs/build
 CREATE_SUBDIRS         = NO
 
-INPUT                  = components/lora_network_layer/include docs
-FILE_PATTERNS          = *.h *.hpp *.md
+INPUT                  = components/lora_network_layer/include docs simulation/include simulation/src simulation/tests/include simulation/docs
+FILE_PATTERNS          = *.h *.hpp *.cpp *.md
 RECURSIVE              = YES
+EXCLUDE                = docs/build
 
 USE_MDFILE_AS_MAINPAGE = docs/mainpage.md
 MARKDOWN_SUPPORT       = YES
 
 OPTIMIZE_OUTPUT_FOR_C  = NO
 EXTRACT_ALL            = YES
-EXTRACT_PRIVATE        = NO
-EXTRACT_STATIC         = NO
+EXTRACT_PRIVATE        = YES
+EXTRACT_STATIC         = YES
 
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html

--- a/docs/doxygen-awesome.css
+++ b/docs/doxygen-awesome.css
@@ -1,0 +1,6 @@
+/* Minimal stylesheet placeholder for Doxygen HTML output.
+ * Replace with a full theme file if desired.
+ */
+:root {
+    --toc-max-height: 80vh;
+}

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -23,6 +23,9 @@ directory:
 Also see the [Network Layer Architecture](architecture.md) page for a
 high-level module and data-flow overview.
 
+For host-side simulation internals and APIs, see the
+[Host Simulation Architecture](../simulation/docs/simulation_architecture.md) page.
+
 ## Notes
 
 This page is configured as the Doxygen main page via

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -1,0 +1,119 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(lora_network_simulation LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(MSVC)
+    add_compile_options(/W4 /permissive-)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+option(SIM_BUILD_DEMO "Build simulation demo executable" ON)
+option(SIM_BUILD_TESTS "Build simulation tests" ON)
+
+set(REPO_ROOT ${CMAKE_CURRENT_LIST_DIR}/..)
+set(NETWORK_COMPONENT_DIR ${REPO_ROOT}/components/lora_network_layer)
+set(NETWORK_INCLUDE_DIR ${NETWORK_COMPONENT_DIR}/include)
+set(NETWORK_SRC_DIR ${NETWORK_COMPONENT_DIR}/src)
+
+add_library(lora_network_core STATIC
+    ${NETWORK_SRC_DIR}/geo_utils.cpp
+    ${NETWORK_SRC_DIR}/duplicate_filter.cpp
+    ${NETWORK_SRC_DIR}/routing_engine.cpp
+    ${NETWORK_SRC_DIR}/forwarding_queue.cpp
+    ${NETWORK_SRC_DIR}/network_manager.cpp
+)
+
+target_include_directories(lora_network_core PUBLIC
+    ${NETWORK_INCLUDE_DIR}
+)
+
+target_compile_features(lora_network_core PUBLIC cxx_std_17)
+
+add_library(network_simulation STATIC
+    src/simulation_clock.cpp
+    src/simulated_location_provider.cpp
+    src/simulated_link_layer.cpp
+    src/simulated_network.cpp
+    src/config_loader.cpp
+    src/simulation_builder.cpp
+)
+
+target_include_directories(network_simulation PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include
+    ${NETWORK_INCLUDE_DIR}
+)
+
+target_link_libraries(network_simulation PUBLIC
+    lora_network_core
+)
+
+target_compile_features(network_simulation PUBLIC cxx_std_17)
+
+if(SIM_BUILD_DEMO)
+    add_executable(simulation_demo src/main.cpp)
+    target_link_libraries(simulation_demo PRIVATE
+        network_simulation
+    )
+endif()
+
+if(SIM_BUILD_TESTS)
+    enable_testing()
+
+    add_library(simulation_test_support STATIC
+        tests/src/simulation_test_base.cpp
+    )
+
+    target_include_directories(simulation_test_support PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/tests/include
+    )
+
+    target_link_libraries(simulation_test_support PUBLIC
+        network_simulation
+    )
+
+    target_compile_features(simulation_test_support PUBLIC cxx_std_17)
+
+    add_executable(simulation_phase3_tests
+        tests/src/test_simulation_phase3.cpp
+    )
+
+    target_link_libraries(simulation_phase3_tests PRIVATE
+        simulation_test_support
+    )
+
+    add_executable(simulation_phase4_tests
+        tests/src/test_simulation_phase4.cpp
+    )
+
+    target_link_libraries(simulation_phase4_tests PRIVATE
+        simulation_test_support
+    )
+
+    add_executable(simulation_phase5_tests
+        tests/src/test_simulation_phase5.cpp
+    )
+
+    target_link_libraries(simulation_phase5_tests PRIVATE
+        simulation_test_support
+    )
+
+    add_test(
+        NAME simulation_phase3_tests
+        COMMAND simulation_phase3_tests
+    )
+
+    add_test(
+        NAME simulation_phase4_tests
+        COMMAND simulation_phase4_tests
+    )
+
+    add_test(
+        NAME simulation_phase5_tests
+        COMMAND simulation_phase5_tests
+    )
+endif()

--- a/simulation/CMakeLists.txt
+++ b/simulation/CMakeLists.txt
@@ -6,11 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(MSVC)
-    add_compile_options(/W4 /permissive-)
-else()
-    add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
+add_compile_options(-Wall -Wextra -Wpedantic)
 
 option(SIM_BUILD_DEMO "Build simulation demo executable" ON)
 option(SIM_BUILD_TESTS "Build simulation tests" ON)
@@ -36,6 +32,8 @@ target_compile_features(lora_network_core PUBLIC cxx_std_17)
 
 add_library(network_simulation STATIC
     src/simulation_clock.cpp
+    src/simulation_event_queue.cpp
+    src/simulation_metrics.cpp
     src/simulated_location_provider.cpp
     src/simulated_link_layer.cpp
     src/simulated_network.cpp

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -24,35 +24,17 @@ For a full guide on writing your own simulation tests, see:
 - `simulation/TESTING_GUIDE.md`
 - `simulation/docs/simulation_architecture.md` (Doxygen architecture and API/internal behavior docs)
 
-## Build with MSVC
+## Build with MinGW
 
 From repository root:
 
 1. Configure
 
-   cmake -S simulation -B simulation/build-msvc -G "Visual Studio 17 2022" -A x64
+   cmake -S simulation -B simulation/build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
 
 2. Build
 
-   cmake --build simulation/build-msvc --config Debug --target simulation_demo
-
-3. Run
-
-   simulation/build-msvc/Debug/simulation_demo.exe
-
-4. Run with a config file
-
-   simulation/build-msvc/Debug/simulation_demo.exe simulation/config/example_network.yml
-
-## Build with Ninja (fallback)
-
-1. Configure
-
-   cmake -S simulation -B simulation/build -G Ninja
-
-2. Build
-
-   cmake --build simulation/build -j
+   cmake --build simulation/build --target simulation_demo -j
 
 3. Run
 
@@ -66,7 +48,7 @@ From repository root:
 
 1. Configure
 
-   cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+   cmake -S simulation -B simulation/build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DSIM_BUILD_TESTS=ON
 
 2. Build tests
 
@@ -84,7 +66,7 @@ From repository root:
 
 1. Configure
 
-   cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+   cmake -S simulation -B simulation/build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DSIM_BUILD_TESTS=ON
 
 2. Build tests
 
@@ -102,7 +84,7 @@ From repository root:
 
 1. Configure
 
-   cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+   cmake -S simulation -B simulation/build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DSIM_BUILD_TESTS=ON
 
 2. Build tests
 

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,124 @@
+# Host Simulation
+
+This folder contains a standalone CMake project for host-side network-layer simulation.
+
+## What is included
+
+- `lora_network_core` static library built from the portable network-layer sources.
+- `network_simulation` static library with:
+  - `SimulationClock`
+  - `SimulatedLocationProvider`
+  - `SimulatedLinkLayer`
+  - `SimulatedNetwork`
+   - `ConfigLoader` (custom YAML subset parser)
+   - `SimulationBuilder` / `SimulationScenario`
+- `simulation_demo` executable that spins up three virtual nodes and sends a sample message.
+- `simulation_phase3_tests` executable with reusable simulation test harness checks.
+- `simulation_phase4_tests` executable with advanced routing and relay scenario checks.
+- `simulation_phase5_tests` executable with scale, repeatability, and timing budget checks.
+
+## Detailed guide
+
+For a full guide on writing your own simulation tests, see:
+
+- `simulation/TESTING_GUIDE.md`
+- `simulation/docs/simulation_architecture.md` (Doxygen architecture and API/internal behavior docs)
+
+## Build with MSVC
+
+From repository root:
+
+1. Configure
+
+   cmake -S simulation -B simulation/build-msvc -G "Visual Studio 17 2022" -A x64
+
+2. Build
+
+   cmake --build simulation/build-msvc --config Debug --target simulation_demo
+
+3. Run
+
+   simulation/build-msvc/Debug/simulation_demo.exe
+
+4. Run with a config file
+
+   simulation/build-msvc/Debug/simulation_demo.exe simulation/config/example_network.yml
+
+## Build with Ninja (fallback)
+
+1. Configure
+
+   cmake -S simulation -B simulation/build -G Ninja
+
+2. Build
+
+   cmake --build simulation/build -j
+
+3. Run
+
+   simulation/build/simulation_demo.exe
+
+4. Run with a config file
+
+   simulation/build/simulation_demo.exe simulation/config/example_network.yml
+
+## Run Phase 3 Tests
+
+1. Configure
+
+   cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+
+2. Build tests
+
+   cmake --build simulation/build --target simulation_phase3_tests -j
+
+3. Run via CTest
+
+   ctest --test-dir simulation/build --output-on-failure
+
+4. Run test binary directly
+
+   simulation/build/simulation_phase3_tests.exe
+
+## Run Phase 4 Tests
+
+1. Configure
+
+   cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+
+2. Build tests
+
+   cmake --build simulation/build --target simulation_phase4_tests -j
+
+3. Run via CTest
+
+   ctest --test-dir simulation/build --output-on-failure -R simulation_phase4_tests
+
+4. Run test binary directly
+
+   simulation/build/simulation_phase4_tests.exe
+
+## Run Phase 5 Tests
+
+1. Configure
+
+   cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+
+2. Build tests
+
+   cmake --build simulation/build --target simulation_phase5_tests -j
+
+3. Run via CTest
+
+   ctest --test-dir simulation/build --output-on-failure -R simulation_phase5_tests
+
+4. Run test binary directly
+
+   simulation/build/simulation_phase5_tests.exe
+
+## Notes
+
+- This simulation project intentionally does not use ESP-IDF build tooling.
+- The current channel model uses free-space path loss and a simple receiver sensitivity threshold.
+- Config files are parsed from a strict YAML-like subset (2-space indentation, list items with `-`).
+- Use `simulation/config/simulation_config.schema.yml` as the field reference.

--- a/simulation/TESTING_GUIDE.md
+++ b/simulation/TESTING_GUIDE.md
@@ -1,0 +1,355 @@
+# Simulation Testing Guide
+
+This guide explains how to use the host simulation to write reliable network-layer tests on a PC (no ESP-IDF runtime required).
+
+## 1. What You Get
+
+The simulation project builds and runs the real network-layer core against host-side adapters:
+
+- Core under test: `NetworkManager`, `RoutingEngine`, `DuplicateFilter`, `ForwardingQueue`.
+- Host adapters:
+  - `SimulatedLinkLayer` for radio transmission/reception.
+  - `SimulatedNetwork` for channel propagation (RSSI/SNR + sensitivity filtering).
+  - `SimulatedLocationProvider` for position, heading, speed, and timestamp.
+  - `SimulationClock` for deterministic virtual time.
+- Test utilities:
+  - `SimulationBuilder` and `SimulationScenario` for composing multi-node scenarios.
+  - `SimulationTestBase` for callback capture, stepping, and waiting assertions.
+
+## 2. Build and Run
+
+From repository root.
+
+### 2.1 Configure + build tests (MSVC)
+
+```powershell
+cmake -S simulation -B simulation/build-msvc -G "Visual Studio 17 2022" -A x64 -DSIM_BUILD_TESTS=ON
+cmake --build simulation/build-msvc --config Debug --target simulation_phase3_tests simulation_phase4_tests simulation_phase5_tests
+```
+
+### 2.2 Run tests (MSVC)
+
+```powershell
+ctest --test-dir simulation/build-msvc -C Debug --output-on-failure
+```
+
+### 2.3 Configure + build tests (Ninja fallback)
+
+```powershell
+cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+cmake --build simulation/build --target simulation_phase3_tests simulation_phase4_tests simulation_phase5_tests -j
+ctest --test-dir simulation/build --output-on-failure
+```
+
+### 2.4 Run one phase only
+
+```powershell
+ctest --test-dir simulation/build --output-on-failure -R simulation_phase4_tests
+```
+
+## 3. Test Project Layout
+
+- `simulation/include/`:
+  - simulation runtime APIs (`SimulationBuilder`, config loader, link/location/network abstractions)
+- `simulation/tests/include/simulation_test_base.h`:
+  - reusable helpers for writing test cases
+- `simulation/tests/src/test_simulation_phase3.cpp`:
+  - baseline delivery/reachability/movement examples
+- `simulation/tests/src/test_simulation_phase4.cpp`:
+  - advanced routing behaviors (TTL, directional, relay, duplicate suppression)
+- `simulation/tests/src/test_simulation_phase5.cpp`:
+  - stress/performance/repeatability patterns
+
+## 4. Two Ways to Define Scenarios
+
+You can define multi-device scenarios in two styles.
+
+### 4.1 Fluent builder API (best for unit tests)
+
+Use `SimulationBuilder` directly in C++ for compact and explicit test setup.
+
+```cpp
+SimulationConfig cfg;
+cfg.runtime.carrier_freq_mhz = 868.0f;
+cfg.runtime.start_time_s = 1000;
+cfg.runtime.network_config = NetworkConfig{64, 8, 16};
+
+SimulationDeviceConfig a;
+a.node_id = 0x2001;
+a.initial_position = GeoPoint{125000000, 773000000};
+a.radio = SimulatedNetwork::RadioConfig{14.0f, -110.0f, -118.0f};
+
+SimulationDeviceConfig b = a;
+b.node_id = 0x2002;
+b.initial_position = GeoPoint{125005000, 773005000};
+
+SimulationBuilder builder;
+builder.setConfig(cfg).addDevice(a).addDevice(b);
+
+std::unique_ptr<SimulationScenario> scenario = builder.build();
+```
+
+### 4.2 File-based config (best for reusable scenarios)
+
+Load scenario from YAML-like config file:
+
+```cpp
+SimulationBuilder builder;
+builder.loadConfigFile("simulation/config/example_network.yml");
+auto scenario = builder.build();
+```
+
+Schema reference: `simulation/config/simulation_config.schema.yml`
+
+Example: `simulation/config/example_network.yml`
+
+## 5. Config Format Rules (Important)
+
+The config parser is intentionally strict.
+
+- Indentation must be multiples of 2 spaces.
+- Comments start with `#`.
+- Top-level sections must be exactly:
+  - `runtime:`
+  - `devices:`
+- List items must use `-` syntax.
+- Unknown keys are rejected with parse errors.
+
+### 5.1 Runtime keys
+
+- `carrier_freq_mhz` (float)
+- `start_time_s` (uint32)
+- `duplicate_cache_size` (size_t)
+- `forwarding_queue_size` (size_t)
+- `rx_queue_depth` (size_t)
+
+### 5.2 Device keys
+
+- `id` or `node_id` (uint16)
+- `lat` / `lon` (int32 fixed-point, degrees × 1e7)
+- `speed_cm_s` (uint16)
+- `heading_cdeg` (uint16, 0.01 degrees)
+- `tx_power_dbm` (float)
+- `noise_floor_dbm` (float)
+- `sensitivity_dbm` (float)
+- optional `waypoints:` list
+
+### 5.3 Waypoint keys
+
+- `at_s` (uint32 timestamp seconds)
+- `lat` / `lon`
+- `speed_cm_s`
+- `heading_cdeg`
+
+Waypoints are sorted by `at_s` and applied when simulation time reaches that second.
+
+## 6. Writing a New Test File
+
+Use this workflow.
+
+1. Create test source in `simulation/tests/src/`, for example `test_simulation_custom.cpp`.
+2. Add a small assertion helper set (`expectTrue`, `expectEqInt`, etc.).
+3. Build a `SimulationConfig` with nodes and radios.
+4. Construct `SimulationTestBase` from `builder.build()`.
+5. Call `start()`.
+6. Trigger traffic using `sendFromDevice(...)`.
+7. Advance/wait with `waitForMessageCount(...)` or `stepUntil(...)`.
+8. Verify payload/header fields.
+9. Call `stop()`.
+10. Register executable + CTest entry in `simulation/CMakeLists.txt`.
+
+Minimal skeleton:
+
+```cpp
+void testScenario()
+{
+    SimulationBuilder builder;
+    builder.setConfig(makeConfig());
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {1,2,3};
+    int rc = test.sendFromDevice(0x2001, payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "send failed");
+
+    expectTrue(test.waitForMessageCount(0x2002, 1, 1500), "receiver timeout");
+    expectTrue(test.hasPayload(0x2002, payload), "payload mismatch");
+
+    test.stop();
+}
+```
+
+## 7. SimulationTestBase API Cheatsheet
+
+From `simulation/tests/include/simulation_test_base.h`:
+
+- `start()` / `stop()`:
+  - starts and stops all managers in scenario.
+- `sendFromDevice(...)`:
+  - sends an app payload from a specific node with full routing controls.
+  - overload accepts raw pointer or `std::vector<uint8_t>`.
+- `receivedCount(node_id)`:
+  - returns number of app-delivered messages captured for a node.
+- `receivedMessages(node_id)`:
+  - returns captured message list (`header` + `payload`).
+- `hasPayload(node_id, payload)`:
+  - convenience payload check.
+- `waitForMessageCount(node_id, min_count, timeout_ms, step_ms, idle_sleep_ms)`:
+  - repeatedly steps simulation and waits until count reached.
+- `stepUntil(predicate, timeout_ms, step_ms, idle_sleep_ms)`:
+  - generic loop for arbitrary stop conditions.
+- `clearCaptured()`:
+  - resets captured callback state for next phase in same test.
+- `scenario()`:
+  - direct access to `SimulationScenario` for low-level stepping and provider inspection.
+
+## 8. Choosing Good Timing Values
+
+Internals to keep in mind:
+
+- `NetworkManager` uses background threads for RX processing and forwarding queue processing.
+- Forwarding queue processing ticks every ~10 ms in host runtime loop.
+- Because callback delivery is asynchronous, avoid immediate strict assertions right after send.
+
+Recommended defaults:
+
+- `step_ms = 50`
+- `idle_sleep_ms = 1..2`
+- receive timeout for normal tests: `1000..2000 ms`
+- stress tests: `3000..5000 ms`
+
+## 9. Routing Controls in sendFromDevice
+
+`sendFromDevice(...)` supports:
+
+- `priority`: `EMERGENCY`, `HIGH`, `NORMAL`, `LOW`
+- `mode`: `OMNI` or `DIRECTIONAL`
+- `target_heading` (centi-degrees)
+- `max_hops`
+- `max_distance_m`
+- `lifetime_s`
+
+Use these to target specific behaviors:
+
+- TTL tests: set small `lifetime_s`, then step virtual time forward.
+- Relay tests: set `max_hops >= 1` and place nodes to force multi-hop.
+- Directional tests: set `mode = DIRECTIONAL` and `target_heading`.
+- Duplicate tests: place a direct path and at least one relay path.
+
+## 10. Inspecting Header-Level Outcomes
+
+Captured messages include `NetworkHeader`, so you can verify:
+
+- `message_id` uniqueness/preservation
+- `hops_remaining` decremented by relays
+- `timestamp` and `lifetime_s`
+- `txPoint()` updated at each relay
+- `originPoint()` unchanged from source
+
+Example checks used in phase tests:
+
+- relay hop decrement on destination
+- destination seeing relay location as transmit point
+
+## 11. Movement and Waypoints
+
+Device movement is kinematics-driven.
+
+- Position advances with each `scenario.step(delta_ms)` using heading + speed.
+- Waypoints are applied when clock reaches `at_s`.
+- If a waypoint is due, location/speed/heading can jump to the waypoint state.
+
+Pattern for movement tests:
+
+1. Send while target is out of range and assert no receive.
+2. Step time beyond waypoint.
+3. Clear captures.
+4. Send again and assert receive.
+
+## 12. Channel Model Summary
+
+`SimulatedNetwork` currently models:
+
+- free-space path loss (FSPL)
+- receiver sensitivity threshold
+- SNR from RSSI - noise floor
+- broadcast and unicast fan-out
+
+It does not currently model multipath fading, packet collisions, or random loss.
+
+## 13. Common Pitfalls
+
+1. Queue capacity mismatch
+
+`NetworkConfig.forwarding_queue_size` should not exceed compile-time max (`CONFIG_NET_FORWARDING_QUEUE_SIZE`, default 8 in this repo).
+
+2. Payload too large
+
+App payload must be <= `NET_MAX_APP_PAYLOAD`.
+
+3. Not starting scenario
+
+Callbacks and runtime threads are active only after `start()`.
+
+4. Immediate assertions
+
+Use wait/step helpers instead of asserting delivery immediately after send.
+
+5. Config indentation issues
+
+Parser rejects odd indentation and unknown fields.
+
+## 14. Add Your Test to CMake and CTest
+
+In `simulation/CMakeLists.txt`:
+
+1. Add executable:
+
+```cmake
+add_executable(simulation_custom_tests
+    tests/src/test_simulation_custom.cpp
+)
+
+target_link_libraries(simulation_custom_tests PRIVATE
+    simulation_test_support
+)
+```
+
+2. Register in CTest:
+
+```cmake
+add_test(
+    NAME simulation_custom_tests
+    COMMAND simulation_custom_tests
+)
+```
+
+3. Build and run:
+
+```powershell
+cmake --build simulation/build --target simulation_custom_tests -j
+ctest --test-dir simulation/build --output-on-failure -R simulation_custom_tests
+```
+
+## 15. Suggested Test Matrix
+
+When adding new features, cover at least:
+
+- delivery success/failure boundaries (range, sensitivity)
+- routing constraints (TTL, hops, max distance)
+- directional behavior
+- relay and duplicate suppression
+- movement transitions via waypoints
+- determinism (same scenario => same result)
+- stress envelope (node count, step count, runtime budget)
+
+## 16. Fast Start Checklist
+
+- Build simulation with `SIM_BUILD_TESTS=ON`.
+- Copy one existing phase test file as a template.
+- Use `SimulationTestBase` helpers (do not reinvent callback capture).
+- Keep scenario config explicit and small first.
+- Add one behavior per test function.
+- Run with CTest filter for fast iteration.
+- Scale up only after deterministic pass.

--- a/simulation/TESTING_GUIDE.md
+++ b/simulation/TESTING_GUIDE.md
@@ -20,28 +20,20 @@ The simulation project builds and runs the real network-layer core against host-
 
 From repository root.
 
-### 2.1 Configure + build tests (MSVC)
+### 2.1 Configure + build tests (MinGW)
 
 ```powershell
-cmake -S simulation -B simulation/build-msvc -G "Visual Studio 17 2022" -A x64 -DSIM_BUILD_TESTS=ON
-cmake --build simulation/build-msvc --config Debug --target simulation_phase3_tests simulation_phase4_tests simulation_phase5_tests
-```
-
-### 2.2 Run tests (MSVC)
-
-```powershell
-ctest --test-dir simulation/build-msvc -C Debug --output-on-failure
-```
-
-### 2.3 Configure + build tests (Ninja fallback)
-
-```powershell
-cmake -S simulation -B simulation/build -G Ninja -DSIM_BUILD_TESTS=ON
+cmake -S simulation -B simulation/build -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DSIM_BUILD_TESTS=ON
 cmake --build simulation/build --target simulation_phase3_tests simulation_phase4_tests simulation_phase5_tests -j
+```
+
+### 2.2 Run tests
+
+```powershell
 ctest --test-dir simulation/build --output-on-failure
 ```
 
-### 2.4 Run one phase only
+### 2.3 Run one phase only
 
 ```powershell
 ctest --test-dir simulation/build --output-on-failure -R simulation_phase4_tests

--- a/simulation/config/example_network.yml
+++ b/simulation/config/example_network.yml
@@ -1,0 +1,40 @@
+runtime:
+  carrier_freq_mhz: 868.0
+  start_time_s: 1000
+  duplicate_cache_size: 64
+  forwarding_queue_size: 8
+  rx_queue_depth: 16
+
+devices:
+  - id: 4097
+    lat: 125000000
+    lon: 773000000
+    speed_cm_s: 80
+    heading_cdeg: 9000
+    tx_power_dbm: 14.0
+    noise_floor_dbm: -110.0
+    sensitivity_dbm: -118.0
+    waypoints:
+      - at_s: 1003
+        lat: 125001000
+        lon: 773002000
+        speed_cm_s: 90
+        heading_cdeg: 4500
+
+  - id: 4098
+    lat: 125005000
+    lon: 773005000
+    speed_cm_s: 40
+    heading_cdeg: 18000
+    tx_power_dbm: 14.0
+    noise_floor_dbm: -110.0
+    sensitivity_dbm: -118.0
+
+  - id: 4099
+    lat: 125030000
+    lon: 773030000
+    speed_cm_s: 0
+    heading_cdeg: 0
+    tx_power_dbm: 14.0
+    noise_floor_dbm: -110.0
+    sensitivity_dbm: -118.0

--- a/simulation/config/simulation_config.schema.yml
+++ b/simulation/config/simulation_config.schema.yml
@@ -1,0 +1,25 @@
+# This is a lightweight schema/reference for the custom YAML subset parsed by ConfigLoader.
+# Indentation must use 2 spaces.
+
+runtime:
+  carrier_freq_mhz: <float>
+  start_time_s: <uint32>
+  duplicate_cache_size: <size_t>
+  forwarding_queue_size: <size_t>
+  rx_queue_depth: <size_t>
+
+devices:
+  - id: <uint16>
+    lat: <int32_fixed_point_1e7>
+    lon: <int32_fixed_point_1e7>
+    speed_cm_s: <uint16>
+    heading_cdeg: <uint16>
+    tx_power_dbm: <float>
+    noise_floor_dbm: <float>
+    sensitivity_dbm: <float>
+    waypoints:
+      - at_s: <uint32>
+        lat: <int32_fixed_point_1e7>
+        lon: <int32_fixed_point_1e7>
+        speed_cm_s: <uint16>
+        heading_cdeg: <uint16>

--- a/simulation/docs/simulation_architecture.md
+++ b/simulation/docs/simulation_architecture.md
@@ -1,0 +1,213 @@
+@page simulation_architecture Host Simulation Architecture
+
+@tableofcontents
+
+## 1. Purpose and Scope
+
+The host simulation subsystem provides a deterministic runtime for exercising
+network-layer behavior on desktop platforms without ESP-IDF dependencies.
+It is designed for:
+
+- fast functional verification of routing and forwarding behavior,
+- reproducible regression tests under controlled virtual time,
+- scale and performance stress runs in CI.
+
+The simulation integrates portable network-layer code (`NetworkManager`,
+`RoutingEngine`, `DuplicateFilter`, `ForwardingQueue`) with host adapters for
+link transport, location, and channel propagation.
+
+## 2. Layered Architecture
+
+The architecture is intentionally split into API-facing composition and internal
+execution mechanisms.
+
+### 2.1 Public API Layer
+
+Primary entry points:
+
+- @ref SimulationBuilder - fluent and file-driven scenario construction.
+- @ref SimulationScenario - runtime ownership and lifecycle control.
+- @ref SimulationClock - virtual time source.
+- @ref SimulatedLocationProvider - deterministic kinematics provider.
+- @ref SimulatedLinkLayer - in-memory `ILinkLayer` implementation.
+- @ref SimulatedNetwork - channel fan-out and propagation checks.
+- @ref ConfigLoader - strict parser for YAML-like config text/files.
+
+Configuration model types:
+
+- @ref SimulationConfig
+- @ref SimulationRuntimeConfig
+- @ref SimulationDeviceConfig
+- @ref SimulationWaypointConfig
+
+### 2.2 Internal Mechanics Layer
+
+Internal behavior centers around three pipelines:
+
+- scenario assembly pipeline (builder -> runtime objects -> manager startup),
+- time/kinematics pipeline (step -> clock advance -> location advance -> waypoint apply),
+- radio delivery pipeline (send -> channel snapshot -> path-loss filter -> callback delivery).
+
+## 3. Scenario Lifecycle
+
+### 3.1 Build Phase
+
+`SimulationBuilder::build()` validates base constraints and creates
+`SimulationScenario`.
+
+Inside `SimulationScenario` construction:
+
+1. Initialize `SimulationClock` from `runtime.start_time_s`.
+2. For each device config:
+   - create `SimulatedLocationProvider` with initial state,
+   - create `SimulatedLinkLayer` bound to shared `SimulatedNetwork`,
+   - register node and radio profile in `SimulatedNetwork`,
+   - create `NetworkManager` using shared runtime queue/cache settings,
+   - normalize waypoint ordering by timestamp.
+3. Apply all waypoints already due at start time.
+
+### 3.2 Run Phase
+
+`SimulationScenario::start()` starts each node's `NetworkManager` threads.
+
+`SimulationScenario::step(delta_ms)` performs deterministic progression:
+
+1. `clock_.step(delta_ms)`
+2. advance all node location providers by `delta_ms`
+3. apply newly due waypoints to each node
+
+### 3.3 Stop Phase
+
+`SimulationScenario::stop()` stops each `NetworkManager`.
+The scenario destructor calls `stop()` to enforce safe teardown.
+
+## 4. Data and Time Model
+
+### 4.1 Time Semantics
+
+- Canonical simulation time is stored in milliseconds (`SimulationClock`).
+- Components that require second precision consume `nowSeconds()`.
+- Location providers track sub-second remainder to preserve timestamp monotonicity.
+
+### 4.2 Position and Motion Semantics
+
+`SimulatedLocationProvider::advance()` computes displacement from:
+
+- speed in cm/s,
+- heading in centi-degrees,
+- elapsed delta in ms.
+
+Heading conventions:
+
+- `0` cdeg: north,
+- `9000` cdeg: east.
+
+The implementation decomposes movement into north/east components and converts
+back to latitude/longitude delta using a spherical Earth approximation.
+
+### 4.3 Waypoint Semantics
+
+Waypoints are discrete state overrides keyed by `at_s`.
+When simulation time reaches or exceeds the waypoint timestamp:
+
+- position, speed, and heading are replaced,
+- waypoint index advances,
+- later waypoints remain pending.
+
+## 5. Radio Channel Model
+
+`SimulatedNetwork` models deterministic in-memory delivery with per-node radio
+profiles.
+
+For each transmit call:
+
+1. Validate payload pointer and length bounds.
+2. Under mutex, snapshot sender and recipient metadata and locations.
+3. Release mutex before callback delivery.
+4. For each recipient:
+   - compute great-circle distance (`geo::haversine_m`),
+   - clamp to minimum distance,
+   - compute RSSI via free-space path-loss,
+   - drop if below receiver sensitivity,
+   - compute SNR (`RSSI - noise floor`),
+   - invoke recipient link callback.
+
+Path-loss equation (text form):
+
+`RSSI_dBm = P_tx_dBm - (32.44 + 20*log10(f_MHz) + 20*log10(d_km))`
+
+SNR equation (text form):
+
+`SNR_dB = RSSI_dBm - NoiseFloor_dBm`
+
+## 6. Config Parsing Architecture
+
+`ConfigLoader` uses a strict staged parser to ensure predictable config behavior.
+
+Parsing stages:
+
+1. Preprocess lines
+   - remove comments (`# ...`),
+   - skip empty lines,
+   - validate indentation is multiples of 2 spaces.
+2. Parse top-level sections
+   - `runtime:`
+   - `devices:`
+3. Parse typed fields with explicit range checks.
+4. Parse nested waypoint lists per device.
+5. Sort waypoints by activation timestamp.
+
+Failure behavior is fail-fast with explicit line-number diagnostics.
+
+## 7. Concurrency and Threading
+
+The simulation runtime combines deterministic stepping with asynchronous manager
+processing threads.
+
+Thread-safety strategy:
+
+- `SimulatedNetwork` uses a mutex to protect node registry and snapshot creation.
+- `SimulatedLinkLayer` protects RX callback installation/read with a mutex.
+- `SimulatedLocationProvider` guards kinematic state with a mutex.
+- `SimulationClock` uses atomic reads/writes.
+
+Determinism considerations:
+
+- virtual time advances only through explicit `step` calls,
+- message processing still uses manager worker threads,
+- test helpers should use stepped waits rather than immediate assertions.
+
+## 8. Test Harness Architecture
+
+`SimulationTestBase` encapsulates common integration-test mechanics:
+
+- scenario lifecycle (`start`, `stop`),
+- source-node traffic injection (`sendFromDevice` overloads),
+- callback capture and message storage by node,
+- polling helpers (`waitForMessageCount`, `stepUntil`),
+- payload/header assertion helpers.
+
+Phase test executables build on this harness:
+
+- phase 3: baseline connectivity and movement,
+- phase 4: relay, TTL, directional, duplicate handling,
+- phase 5: stress, repeatability, and timing budget.
+
+## 9. Extension Points
+
+Recommended extension points for future simulation features:
+
+- richer channel effects (collision, fading, stochastic loss),
+- configurable asynchronous delay/jitter model,
+- scripted mobility model beyond waypoint overrides,
+- scenario metrics export for CI dashboards.
+
+## 10. Current Limitations
+
+Known simplifications in current implementation:
+
+- no collision/interference model,
+- no random packet-loss model,
+- no terrain/obstacle attenuation,
+- deterministic path-loss-only propagation,
+- strict custom YAML subset rather than full YAML parser.

--- a/simulation/docs/simulation_wireless_upgrade_design.md
+++ b/simulation/docs/simulation_wireless_upgrade_design.md
@@ -1,0 +1,586 @@
+@page simulation_wireless_upgrade_design Wireless Simulation Upgrade Design
+
+@tableofcontents
+
+## 1. Goals and Non-Goals
+
+### 1.1 Goals
+
+- Add realistic medium-access and channel behavior while preserving deterministic, seed-reproducible runs.
+- Keep existing layered architecture: `SimulationScenario` orchestrates runtime, `SimulatedNetwork` remains radio core model.
+- Preserve current tests by default through backward-compatible configuration defaults.
+- Scale to large host simulations (100+ nodes, long stepped runs) with bounded overhead.
+
+### 1.2 Non-Goals (for this upgrade wave)
+
+- Full PHY waveform simulation.
+- Real-time wall-clock scheduling.
+- Terrain/obstacle ray tracing.
+- Refactoring `NetworkManager` business logic unless strictly required for MAC integration.
+
+## 2. High-Level Architecture Changes
+
+Current model is immediate delivery in `SimulatedNetwork::transmit(...)` with deterministic path-loss checks.
+Target model introduces a deterministic event-driven channel timeline with explicit medium occupancy and transmission durations.
+
+### 2.1 Proposed runtime layers after upgrade
+
+- Scenario Orchestration Layer
+  - `SimulationScenario` owns and advances virtual time.
+  - `SimulationScenario` drives deterministic event execution in time order during `step(delta_ms)`.
+- Channel/MAC Layer (new responsibilities)
+  - `SimulatedNetwork` remains the central radio model and now owns:
+    - channel state (busy windows, active transmissions),
+    - event scheduling hooks for TX start/end and delivery,
+    - collision and PER decisions,
+    - channel metrics accounting.
+- Link Adapter Layer
+  - `SimulatedLinkLayer::send(...)` changes from immediate propagation call to enqueueing TX request into network MAC pipeline.
+- Mobility/Location Layer
+  - unchanged API; still queried at deterministic event timestamps.
+
+### 2.2 Design decision: channel scope
+
+- Channel occupancy model is per-frequency-channel, not a single global busy flag.
+- Backward-compatible default: one logical channel using existing `runtime.carrier_freq_mhz`.
+- Future-proofing: optional channel index per node/message for multi-channel scenarios.
+
+## 3. Updated Packet Flow Pipeline (Before vs After)
+
+### 3.1 Before
+
+1. `NetworkManager` calls `ILinkLayer::send(...)`
+2. `SimulatedLinkLayer` immediately calls `SimulatedNetwork::transmit(...)`
+3. `SimulatedNetwork` snapshots nodes, computes RSSI/SNR, applies sensitivity cutoff
+4. Recipients receive callback immediately
+
+### 3.2 After
+
+1. `NetworkManager` calls `ILinkLayer::send(...)`
+2. `SimulatedLinkLayer` submits `TxRequest` to `SimulatedNetwork`
+3. `SimulatedNetwork` computes carrier sense at request time:
+   - if idle: schedule `TxStartEvent` at current virtual time
+   - if busy: schedule retry/backoff event using deterministic seeded RNG
+4. `SimulationScenario::step(...)` advances clock and drains event queue up to step horizon
+5. `TxStartEvent`:
+   - reserve channel occupancy window
+   - register active transmission record
+   - schedule `TxEndEvent`
+   - schedule per-recipient `RxDeliveryEvent` at propagation delay offset
+6. Collision/PER/noise/fading are evaluated at delivery or TX end depending on selected model
+7. Successful deliveries invoke `SimulatedLinkLayer::deliverFromNetwork(...)`
+8. Metrics are updated continuously (attempts, collisions, delivery, latency, utilization)
+
+## 4. New and Updated Components
+
+## 4.1 New components
+
+- `SimulationEventQueue` (deterministic scheduler)
+  - Min-heap ordered by `(time_us, priority, sequence_id)`.
+  - Deterministic tie-break with monotonic `sequence_id`.
+  - Supports event cancelation by token (optional, useful for dropped retries).
+
+- `ChannelStateTable`
+  - Maintains per-channel busy window and active transmissions.
+  - Fast carrier-sense checks.
+  - Collision overlap tracking.
+
+- `MacNodeState`
+  - Per-node contention state:
+    - CW min/max,
+    - retry count,
+    - current backoff slots,
+    - pending outbound queue depth.
+
+- `DeterministicRngService`
+  - Central seeded random source with deterministic substreams.
+  - Supports:
+    - MAC backoff draws,
+    - PER Bernoulli draws,
+    - fading/noise perturbations.
+
+- `SimulationMetricsCollector`
+  - Runtime counters and histogram-like summaries.
+  - Exposed via `SimulationScenario` read APIs.
+
+## 4.2 Updated existing components
+
+- `SimulationScenario`
+  - Owns scheduler tick loop integration in `step(delta_ms)`.
+  - Exposes metrics snapshot API.
+
+- `SimulatedNetwork`
+  - Adds request ingress API (enqueue TX request).
+  - Adds event handlers:
+    - onTxStart
+    - onTxEnd
+    - onRetryBackoff
+    - onRxDelivery
+  - Adds collision/PER/fading logic.
+
+- `SimulatedLinkLayer`
+  - `send` becomes enqueue + status return; no immediate fan-out.
+  - RX callback contract remains unchanged.
+
+- `SimulationConfig` and `ConfigLoader`
+  - Add runtime and radio/MAC knobs with backward-compatible defaults.
+
+## 5. Core Data Structures (Pseudocode)
+
+    enum class SimEventType {
+      TxStart,
+      TxEnd,
+      RetryBackoff,
+      RxDelivery
+    };
+
+    struct SimEvent {
+      uint64_t time_us;
+      uint8_t priority;           // lower = earlier within same timestamp
+      uint64_t sequence_id;       // deterministic tie-break
+      SimEventType type;
+      uint16_t node_id;
+      uint32_t tx_id;
+      uint16_t dst_id;            // optional for unicast events
+    };
+
+    struct TxRequest {
+      uint32_t tx_id;
+      uint16_t src_node_id;
+      uint16_t dst_id;
+      std::vector<uint8_t> payload;
+      uint64_t requested_at_us;
+      uint8_t max_retries;
+      uint8_t attempt_index;
+      uint8_t channel_index;
+    };
+
+    struct ActiveTransmission {
+      uint32_t tx_id;
+      uint16_t src_node_id;
+      uint8_t channel_index;
+      uint64_t start_us;
+      uint64_t end_us;
+      float tx_power_dbm;
+      bool collided;
+    };
+
+    struct ChannelState {
+      uint64_t busy_until_us;
+      std::vector<uint32_t> active_tx_ids;
+      uint64_t busy_accumulated_us;
+      uint64_t last_utilization_update_us;
+    };
+
+    struct MacNodeState {
+      uint16_t node_id;
+      uint16_t cw_min;
+      uint16_t cw_max;
+      uint16_t cw_current;
+      uint8_t retry_count;
+      uint64_t next_eligible_tx_us;
+    };
+
+    struct SimulationMetricsSnapshot {
+      uint64_t tx_attempts;
+      uint64_t tx_success;
+      uint64_t tx_fail_collision;
+      uint64_t tx_fail_per;
+      uint64_t retransmissions;
+      uint64_t rx_delivered;
+      uint64_t rx_dropped;
+      double packet_delivery_ratio;
+      double average_latency_ms;
+      double channel_utilization_pct;
+    };
+
+## 6. Time Model and Determinism
+
+### 6.1 Internal time precision
+
+- Keep existing external API in milliseconds (`step(delta_ms)`, `nowMs()` compatibility).
+- Add internal microsecond timeline for radio events (`time_us`) to model:
+  - transmission duration,
+  - slot timing,
+  - propagation delay.
+
+### 6.2 Deterministic ordering rules
+
+Events execute in strict order:
+
+1. `time_us` ascending
+2. event-type priority (control before delivery when equal timestamp)
+3. `sequence_id` ascending
+
+Recommended event-type priority at identical timestamp:
+
+- `TxEnd` before `TxStart` before `RetryBackoff` before `RxDelivery`
+
+This avoids ambiguous occupancy transitions at exact boundaries.
+
+### 6.3 Randomness determinism
+
+- Single scenario seed from config (`runtime.random_seed`).
+- Derive deterministic substreams by stable tuple hashing:
+  - `(seed, node_id, tx_id, purpose_tag)`
+- Avoid consuming random numbers in nondeterministic loop orders.
+- Optional stronger guarantee: stateless random function for each draw key.
+
+## 7. Feature Designs
+
+### 7.1 Channel Occupancy (Carrier Sense)
+
+- Maintain `ChannelState.busy_until_us` and active tx set per channel.
+- Carrier-sense check at TX attempt time:
+  - idle if `now_us >= busy_until_us` and active set empty.
+  - busy otherwise.
+- On TX start, set `busy_until_us = max(busy_until_us, tx_end_us)`.
+
+Thread safety:
+
+- Continue mutex protection inside `SimulatedNetwork` for shared state.
+- Event execution and state mutation happen in scheduler-driven deterministic context.
+
+### 7.2 Transmission Time Modeling
+
+Introduce airtime formula:
+
+    tx_duration_us = preamble_us +
+                     ceil((phy_overhead_bytes + payload_len_bytes) * 8e6 / data_rate_bps)
+
+Configurable terms:
+
+- `data_rate_bps`
+- `phy_overhead_bytes`
+- `preamble_us`
+
+Behavior:
+
+- delivery is no longer instantaneous;
+- `TxEndEvent` marks channel release;
+- receiver delivery scheduled at `TxStart + propagation_delay + rx_processing_offset`.
+
+### 7.3 Event Scheduling System
+
+Placement decision:
+
+- Scheduler owned by `SimulationScenario`.
+- `SimulatedNetwork` registers events through scheduler interface.
+
+Rationale:
+
+- Keeps virtual-time authority in scenario.
+- Allows future non-radio event types (mobility triggers, scripted faults) without cyclic dependencies.
+
+### 7.4 Random Backoff (CSMA/CA-like)
+
+Per-node algorithm:
+
+1. If channel busy, draw slot count `k` from `[0, cw_current]`.
+2. Schedule retry at `now + DIFS + k * slot_time_us`.
+3. On retry failure, increase CW exponentially:
+   - `cw_current = min((2 * cw_current + 1), cw_max)`
+4. On success, reset to `cw_min`.
+5. Stop after `max_retries` and count failure.
+
+Config parameters:
+
+- `slot_time_us`
+- `difs_us`
+- `cw_min`
+- `cw_max`
+- `max_retries`
+
+### 7.5 Collision Detection
+
+Baseline strategy for first rollout:
+
+- If two or more transmissions overlap in time on same channel and both are receivable at a node, mark collided and drop affected receptions.
+
+Optional enhancement (phase 2+): capture effect
+
+- If strongest signal exceeds second-strongest by `capture_threshold_db`, allow decode.
+
+Complexity control:
+
+- Only compare against currently active transmissions in channel state.
+- Avoid all-pairs over historical transmissions.
+
+### 7.6 Packet Error Model (PER)
+
+Support model modes:
+
+- `threshold` (legacy-like deterministic): success if `snr_db >= snr_min_db`.
+- `logistic`: `p_success = 1 / (1 + exp(-k*(snr_db - snr_mid_db)))`.
+- `table`: piecewise-linear interpolation from configured SNR/PER points.
+
+Delivery decision:
+
+- deterministic RNG draw `u` in [0,1)
+- success if `u < p_success`
+
+### 7.7 Channel Noise and Fading
+
+Add small stochastic terms before PER decision:
+
+- `rssi_eff = rssi_nominal + fade_db + noise_jitter_db`
+- defaults keep current behavior (`fade_stddev_db = 0`, `noise_jitter_db = 0`).
+
+Initial model:
+
+- zero-mean bounded gaussian-like perturbation (clamped)
+- optional slowly varying noise floor process by channel
+
+### 7.8 Propagation Delay
+
+Delay model:
+
+    propagation_delay_us = max(min_delay_us,
+                               round(distance_m / c_m_per_s * 1e6))
+
+Defaults:
+
+- `min_delay_us = 0` for strict legacy alignment.
+- optional non-zero minimum to avoid same-timestamp artifacts.
+
+### 7.9 Channel Utilization and Congestion
+
+- Track busy-time accumulation per channel:
+  - integrate occupied intervals during event execution.
+- expose utilization as:
+
+    utilization = busy_time_us / elapsed_time_us
+
+Optional congestion drop model (feature-gated):
+
+- if utilization over rolling window exceeds threshold, apply extra drop probability.
+
+### 7.10 Metrics Collection API
+
+Expose from scenario:
+
+- snapshot query:
+  - `SimulationMetricsSnapshot SimulationScenario::metrics() const`
+- optional reset:
+  - `void SimulationScenario::resetMetrics()`
+
+Metrics include:
+
+- packet delivery ratio
+- latency (mean, min/max, optional percentiles)
+- collision count
+- retransmission count
+- channel utilization
+
+### 7.11 Config Extensions
+
+Runtime additions (example):
+
+- `random_seed` (uint64)
+- `scheduler_time_unit` (fixed internally, optional read-only)
+- `data_rate_bps`
+- `phy_overhead_bytes`
+- `preamble_us`
+- `slot_time_us`
+- `difs_us`
+- `cw_min`, `cw_max`, `max_retries`
+- `per_model` and model coefficients/table
+- `fading_stddev_db`, `noise_jitter_db`
+- `propagation_min_delay_us`
+- `enable_collision_model`
+- `enable_congestion_drops`
+
+Node/radio optional additions:
+
+- `channel_index`
+- `capture_threshold_db`
+
+Backward compatibility:
+
+- defaults selected to emulate current behavior:
+  - collision disabled,
+  - PER threshold pass-through,
+  - zero jitter/fading,
+  - immediate-like minimal durations if desired in compatibility profile.
+
+## 8. Interaction Diagram
+
+```mermaid
+sequenceDiagram
+    participant NM as NetworkManager
+    participant LL as SimulatedLinkLayer
+    participant SN as SimulatedNetwork
+    participant SS as SimulationScenario
+    participant EQ as EventQueue
+    participant RX as Receiver Link
+
+    NM->>LL: send(dst, payload)
+    LL->>SN: submitTxRequest(req)
+    SN->>EQ: schedule(TxStart or RetryBackoff)
+
+    loop during step(delta)
+      SS->>EQ: pop events <= horizon
+      EQ-->>SN: dispatch(event)
+      alt TxStart
+        SN->>SN: reserve channel + create active tx
+        SN->>EQ: schedule(TxEnd)
+        SN->>EQ: schedule(RxDelivery per recipient)
+      else RetryBackoff
+        SN->>SN: carrier sense + CW update
+        SN->>EQ: reschedule attempt
+      else RxDelivery
+        SN->>SN: collision/PER/fading decision
+        alt success
+          SN->>RX: deliverFromNetwork(data, rssi, snr)
+        else drop
+          SN->>SN: update metrics
+        end
+      else TxEnd
+        SN->>SN: release channel occupancy
+      end
+    end
+```
+
+## 9. Incremental Integration Plan
+
+### Phase 0: Compatibility scaffolding
+
+- Add config fields with defaults preserving current behavior.
+- Add metrics collector skeleton and API getters returning baseline values.
+- No behavior changes yet.
+
+Exit criteria:
+
+- all existing simulation tests pass unchanged.
+
+### Phase 1: Deterministic event queue foundation
+
+- Introduce scheduler and event types.
+- Route `SimulatedLinkLayer::send` through request queue.
+- Keep immediate-delivery compatibility mode enabled by default.
+
+Exit criteria:
+
+- deterministic replay test added and passing.
+- phase 3/4/5 tests remain green.
+
+### Phase 2: TX duration + channel occupancy
+
+- Add airtime computation and busy window tracking.
+- Implement carrier-sense gate and TX start/end events.
+- Add simple backoff without exponential growth first.
+
+Exit criteria:
+
+- channel busy tests passing.
+- no regression in base functionality under compatibility config.
+
+### Phase 3: CSMA/CA backoff + collisions
+
+- Add CW growth/reset and retry caps.
+- Add overlap-based collision drops.
+- Add collision metrics.
+
+Exit criteria:
+
+- targeted collision and retransmission tests passing.
+
+### Phase 4: PER + fading + noise + propagation delay
+
+- Add probabilistic delivery model and deterministic RNG integration.
+- Enable delay-aware delivery scheduling.
+- Add reproducibility checks with fixed seeds.
+
+Exit criteria:
+
+- repeated runs with same seed produce identical snapshots.
+- different seeds produce expected statistical variation.
+
+### Phase 5: Utilization + congestion model + optimization
+
+- Add utilization accounting and optional congestion drops.
+- Profile and optimize active-transmission scanning and scheduler hot paths.
+
+Exit criteria:
+
+- performance budget sustained for 100-node stress scenarios.
+
+## 10. Risks and Trade-offs
+
+- Increased complexity in event ordering
+  - Mitigation: strict ordering tuple and centralized scheduler tests.
+- Potential nondeterminism from asynchronous manager threads
+  - Mitigation: all channel decisions happen in deterministic event loop, stable tie-break keys, seeded stateless draws.
+- Performance overhead from collision checks
+  - Mitigation: per-channel active set only, avoid historical scans, feature flags for heavy models.
+- Backward compatibility risk for timing-sensitive tests
+  - Mitigation: compatibility profile defaults and phased opt-in tests.
+- Config bloat
+  - Mitigation: grouped config blocks, sensible defaults, parser validation with clear errors.
+
+## 11. Testing Strategy
+
+### 11.1 Unit tests (new)
+
+- Scheduler ordering and tie-break determinism.
+- Airtime calculation correctness.
+- Carrier-sense state transitions.
+- Backoff CW growth/reset logic.
+- PER mapping function correctness.
+- Seed reproducibility for RNG service.
+
+### 11.2 Integration tests (simulation)
+
+- Existing phase 3/4/5 regression suite under compatibility defaults.
+- New CSMA tests:
+  - busy-channel defer,
+  - retry then success,
+  - retry exhaustion.
+- Collision tests:
+  - overlapping TX causes drop,
+  - optional capture threshold behavior.
+- Propagation tests:
+  - farther node receives later than closer node (when delay enabled).
+
+### 11.3 Determinism tests
+
+- same seed + same workload => identical per-node message hashes and metrics.
+- seed change => reproducible but different statistical outcomes.
+- run-to-run equality across multiple repetitions in CI.
+
+### 11.4 Performance tests
+
+- maintain or improve current phase-5 step budget constraints.
+- add profile scenarios for high contention and high event density.
+
+## 12. Small, Testable Commit Suggestions
+
+1. Commit A: Config and API scaffolding
+   - Add new config fields with defaults.
+   - Add metrics snapshot structs and no-op collector wiring.
+
+2. Commit B: Deterministic event queue core
+   - Add scheduler, event IDs, and deterministic ordering tests.
+
+3. Commit C: Link-layer send path migration
+   - Route send through request enqueue.
+   - Keep compatibility immediate mode active.
+
+4. Commit D: TX duration and carrier-sense occupancy
+   - Implement TxStart/TxEnd events and busy window tests.
+
+5. Commit E: Backoff and retry policy
+   - Add per-node CW state and retry scheduling tests.
+
+6. Commit F: Collision model (drop-on-overlap)
+   - Add active transmission overlap checks and collision metrics tests.
+
+7. Commit G: PER and fading/noise model
+   - Add SNR-to-probability mapping and seeded probabilistic tests.
+
+8. Commit H: Propagation delay and utilization metrics
+   - Add delay scheduling and channel busy percentage accounting.
+
+9. Commit I: Integration and documentation updates
+   - Extend simulation test matrix.
+   - Update architecture docs with operational examples.

--- a/simulation/include/config_loader.h
+++ b/simulation/include/config_loader.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+#include "simulation_config.h"
+
+/**
+ * @file config_loader.h
+ * @ingroup sim_config
+ * @brief Strict parser utilities for file-based simulation scenarios.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief Loads @ref SimulationConfig from disk or in-memory text.
+ *
+ * The parser accepts a constrained YAML-like format intended for deterministic tests.
+ * Validation is strict: unknown keys, malformed indentation, or out-of-range values
+ * produce @c std::runtime_error with line-level diagnostics.
+ */
+class ConfigLoader {
+public:
+    /**
+     * @brief Load and parse a simulation config file.
+     * @param file_path Path to the config file.
+     * @return Parsed and validated simulation configuration.
+     * @throws std::runtime_error If the file cannot be opened or parsing fails.
+     */
+    static SimulationConfig loadFromFile(const std::string& file_path);
+
+    /**
+     * @brief Parse simulation config content from text.
+     * @param text Full config text in the supported YAML-like grammar.
+     * @return Parsed and validated simulation configuration.
+     * @throws std::runtime_error If syntax or semantic validation fails.
+     */
+    static SimulationConfig parseText(const std::string& text);
+};

--- a/simulation/include/simulated_link_layer.h
+++ b/simulation/include/simulated_link_layer.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+
+#include "link_layer_interface.h"
+
+class SimulatedNetwork;
+
+/**
+ * @file simulated_link_layer.h
+ * @ingroup sim_channel
+ * @brief Host link-layer adapter bridging NetworkManager and SimulatedNetwork.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief In-memory link-layer implementation for simulation nodes.
+ *
+ * Outbound traffic is forwarded to @ref SimulatedNetwork::transmit. Inbound
+ * frames are delivered through the registered @ref RxHandler callback.
+ */
+class SimulatedLinkLayer : public ILinkLayer {
+public:
+    /**
+     * @brief Construct a simulated link interface for one node.
+     * @param node_id Node identifier exposed to network-layer logic.
+     * @param network Shared simulated radio channel.
+     */
+    SimulatedLinkLayer(uint16_t node_id, SimulatedNetwork& network);
+
+    /**
+     * @brief Destructor unregisters the node from the simulated network.
+     */
+    ~SimulatedLinkLayer() override;
+
+    /** @copydoc ILinkLayer::send */
+    int send(uint16_t dstId, const uint8_t* data, size_t len) override;
+    /** @copydoc ILinkLayer::setRxHandler */
+    void setRxHandler(RxHandler handler) override;
+    /** @copydoc ILinkLayer::getNodeId */
+    uint16_t getNodeId() const override;
+
+    /**
+     * @brief Inject a received frame from the simulated channel.
+     * @param data Pointer to payload bytes.
+     * @param len Payload length in bytes.
+     * @param rssi Received signal strength in dBm.
+     * @param snr Signal-to-noise ratio in dB.
+     */
+    void deliverFromNetwork(const uint8_t* data, size_t len, float rssi, float snr);
+
+private:
+    uint16_t node_id_;
+    SimulatedNetwork& network_;
+    mutable std::mutex mutex_;
+    RxHandler handler_;
+};

--- a/simulation/include/simulated_location_provider.h
+++ b/simulation/include/simulated_location_provider.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+
+#include "location_provider.h"
+
+/**
+ * @file simulated_location_provider.h
+ * @ingroup sim_runtime
+ * @brief Host implementation of @ref ILocationProvider with deterministic kinematics.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief Deterministic, thread-safe location provider for simulated nodes.
+ *
+ * State is expressed as position + speed + heading + timestamp and can be
+ * advanced in virtual time via @ref advance. The implementation assumes a
+ * spherical Earth approximation for short-distance stepping.
+ */
+class SimulatedLocationProvider : public ILocationProvider {
+public:
+    /**
+     * @brief Instantaneous motion state at a simulation timestamp.
+     */
+    struct Kinematics {
+        /** Geodetic position in fixed-point degrees (deg * 1e7). */
+        GeoPoint position;
+        /** Speed in centimeters per second. */
+        uint16_t speed_cm_s;
+        /** Heading in centi-degrees, where 0 is north and 9000 is east. */
+        uint16_t heading_cdeg;
+        /** Timestamp in whole seconds. */
+        uint32_t timestamp_s;
+    };
+
+    /**
+     * @brief Construct provider with initial kinematic state.
+     */
+    explicit SimulatedLocationProvider(const Kinematics& initial);
+
+    /** @copydoc ILocationProvider::getLocation */
+    GeoPoint getLocation() const override;
+    /** @copydoc ILocationProvider::getSpeed */
+    uint16_t getSpeed() const override;
+    /** @copydoc ILocationProvider::getHeading */
+    uint16_t getHeading() const override;
+    /** @copydoc ILocationProvider::getTimestamp */
+    uint32_t getTimestamp() const override;
+
+    /**
+     * @brief Replace current state atomically.
+     * @param state New kinematic state to apply immediately.
+     */
+    void setKinematics(const Kinematics& state);
+
+    /**
+     * @brief Advance node position and timestamp by a virtual-time delta.
+     * @param delta_ms Virtual milliseconds to advance.
+     */
+    void advance(uint64_t delta_ms);
+
+private:
+    mutable std::mutex mutex_;
+    Kinematics state_;
+    uint16_t subsecond_ms_{0};
+};

--- a/simulation/include/simulated_network.h
+++ b/simulation/include/simulated_network.h
@@ -2,8 +2,13 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <atomic>
 #include <mutex>
 #include <unordered_map>
+#include <vector>
+
+#include "simulation_event_queue.h"
+#include "simulation_metrics.h"
 
 class SimulatedLinkLayer;
 class SimulatedLocationProvider;
@@ -43,8 +48,10 @@ public:
     /**
      * @brief Construct channel model.
      * @param carrier_freq_mhz Carrier frequency in MHz for path-loss calculations.
+      * @param compatibility_immediate_delivery Keep immediate-delivery compatibility behavior.
      */
-    explicit SimulatedNetwork(float carrier_freq_mhz = 868.0f);
+     explicit SimulatedNetwork(float carrier_freq_mhz = 868.0f,
+                                        bool compatibility_immediate_delivery = true);
 
     /**
      * @brief Register a node with default radio profile.
@@ -76,7 +83,41 @@ public:
     void transmit(uint16_t src_node_id,
                   uint16_t dst_id,
                   const uint8_t* data,
-                  size_t len) const;
+                  size_t len);
+
+    /** @brief Configure timing and retry parameters for queued channel access. */
+    void configureMac(uint32_t data_rate_bps,
+                      uint32_t slot_time_us,
+                      uint32_t difs_us,
+                      uint8_t max_retries,
+                      uint32_t propagation_min_delay_us,
+                      uint16_t cw_min,
+                      uint16_t cw_max,
+                      uint64_t random_seed,
+                      bool enable_collision_model,
+                      uint8_t per_model,
+                      float snr_threshold_db,
+                      float per_logistic_k,
+                      float per_logistic_mid_db,
+                      float fading_stddev_db,
+                      float noise_jitter_db,
+                      bool enable_congestion_drops,
+                      float congestion_utilization_threshold_pct,
+                      float congestion_drop_probability,
+                      uint32_t congestion_min_elapsed_us);
+
+    /** @brief Update current virtual time marker used by enqueueing send operations. */
+    void setNowUs(uint64_t now_us);
+    /** @brief Current virtual time marker in microseconds. */
+    uint64_t nowUs() const;
+
+    /** @brief Process all queued events with timestamp <= @p horizon_us. */
+    void processUntil(uint64_t horizon_us);
+
+    /** @brief Snapshot current channel and delivery metrics. */
+    SimulationMetricsSnapshot metricsSnapshot(uint64_t sim_now_us) const;
+    /** @brief Reset metrics counters using @p now_us as baseline. */
+    void resetMetrics(uint64_t now_us = 0);
 
 private:
     struct NodeEntry {
@@ -85,10 +126,83 @@ private:
         RadioConfig cfg;
     };
 
+    struct ActiveTransmission {
+        uint64_t tx_id;
+        uint16_t src_node_id;
+        uint64_t start_us;
+        uint64_t end_us;
+        bool collided;
+    };
+
+    struct TxDeliveryState {
+        size_t pending_deliveries;
+        bool any_delivered;
+        bool any_per_drop;
+        bool collided;
+        uint64_t tx_end_us;
+    };
+
     static float computeRssiDbm(float tx_power_dbm, float distance_m, float carrier_freq_mhz);
     static float computeSnrDb(float rssi_dbm, float noise_floor_dbm);
+    uint64_t computeTxDurationUs(size_t payload_len_bytes) const;
+    uint64_t computeBackoffSlots(uint16_t src_node_id,
+                                 uint8_t retry_count,
+                                 uint64_t tx_id,
+                                 uint16_t cw_current) const;
+    double deterministicUnitInterval(uint64_t key_a,
+                                     uint64_t key_b,
+                                     uint64_t key_c) const;
+    float sampleFadingDb(uint64_t tx_id, uint16_t dst_node_id) const;
+    float sampleNoiseJitterDb(uint64_t tx_id, uint16_t dst_node_id) const;
+    bool evaluatePerSuccess(float snr_db, uint64_t tx_id, uint16_t dst_node_id) const;
+    bool shouldDropForCongestion(uint64_t event_time_us,
+                                 uint64_t tx_id,
+                                 uint16_t dst_node_id) const;
+    static uint64_t mix64(uint64_t x);
+
+    uint16_t getOrInitCwState(uint16_t node_id);
+    void resetCwState(uint16_t node_id);
+
+    void executeTxStartEvent(const SimEvent& event);
+    void executeRetryBackoffEvent(const SimEvent& event);
+    void executeTxEndEvent(const SimEvent& event);
+    void executeDeliveryEvent(const SimEvent& event);
+    uint64_t nextSequenceId();
 
     float carrier_freq_mhz_;
+    bool compatibility_immediate_delivery_;
+    std::atomic<uint64_t> now_us_{0};
+    std::atomic<uint64_t> next_sequence_id_{1};
+    uint64_t channel_busy_until_us_{0};
+
+    uint32_t data_rate_bps_{50000};
+    uint32_t slot_time_us_{1000};
+    uint32_t difs_us_{0};
+    uint8_t max_retries_{4};
+    uint32_t propagation_min_delay_us_{0};
+    uint16_t cw_min_{3};
+    uint16_t cw_max_{1023};
+    uint64_t random_seed_{1};
+    bool enable_collision_model_{false};
+    uint8_t per_model_{0};
+    float snr_threshold_db_{-200.0f};
+    float per_logistic_k_{1.0f};
+    float per_logistic_mid_db_{0.0f};
+    float fading_stddev_db_{0.0f};
+    float noise_jitter_db_{0.0f};
+    bool enable_congestion_drops_{false};
+    float congestion_utilization_threshold_pct_{95.0f};
+    float congestion_drop_probability_{0.0f};
+    uint32_t congestion_min_elapsed_us_{1000};
+    uint64_t channel_busy_accumulated_us_{0};
+    uint64_t utilization_start_time_us_{0};
+
     mutable std::mutex mutex_;
     std::unordered_map<uint16_t, NodeEntry> nodes_;
+    std::unordered_map<uint16_t, uint16_t> cw_state_by_node_;
+    std::unordered_map<uint64_t, ActiveTransmission> active_transmissions_;
+    std::unordered_map<uint64_t, TxDeliveryState> tx_delivery_state_;
+
+    SimulationEventQueue event_queue_;
+    SimulationMetricsCollector metrics_;
 };

--- a/simulation/include/simulated_network.h
+++ b/simulation/include/simulated_network.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+
+class SimulatedLinkLayer;
+class SimulatedLocationProvider;
+
+/**
+ * @file simulated_network.h
+ * @ingroup sim_channel
+ * @brief In-memory radio channel model used by host simulation nodes.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief Simulated LoRa channel that fans out frames across registered nodes.
+ *
+ * For each transmission, the channel snapshots sender/receiver states,
+ * computes free-space path loss and SNR, and delivers only when the receiver's
+ * sensitivity threshold is met.
+ *
+ * Receive power model (text form):
+ * RSSI_dBm = P_tx_dBm - (32.44 + 20*log10(f_MHz) + 20*log10(d_km)).
+ * SNR_dB = RSSI_dBm - NoiseFloor_dBm.
+ */
+class SimulatedNetwork {
+public:
+    /**
+     * @brief Per-node radio profile applied during propagation checks.
+     */
+    struct RadioConfig {
+        /** Transmit power in dBm used by the source node. */
+        float tx_power_dbm = 14.0f;
+        /** Receiver noise floor in dBm for SNR estimation. */
+        float noise_floor_dbm = -110.0f;
+        /** Minimum RSSI in dBm required to deliver a frame. */
+        float sensitivity_dbm = -120.0f;
+    };
+
+    /**
+     * @brief Construct channel model.
+     * @param carrier_freq_mhz Carrier frequency in MHz for path-loss calculations.
+     */
+    explicit SimulatedNetwork(float carrier_freq_mhz = 868.0f);
+
+    /**
+     * @brief Register a node with default radio profile.
+     */
+    void registerNode(uint16_t node_id,
+                      SimulatedLinkLayer* link,
+                      const SimulatedLocationProvider* location);
+
+    /**
+     * @brief Register or replace a node with explicit radio profile.
+     */
+    void registerNode(uint16_t node_id,
+                      SimulatedLinkLayer* link,
+                      const SimulatedLocationProvider* location,
+                      const RadioConfig& cfg);
+
+    /** @brief Remove a node from the channel registry. */
+    void unregisterNode(uint16_t node_id);
+    /** @brief Current number of registered nodes. */
+    size_t nodeCount() const;
+
+    /**
+     * @brief Transmit a frame to one node or broadcast to all reachable nodes.
+     * @param src_node_id Source node id.
+     * @param dst_id Destination node id or broadcast address.
+     * @param data Frame payload pointer.
+     * @param len Payload length in bytes.
+     */
+    void transmit(uint16_t src_node_id,
+                  uint16_t dst_id,
+                  const uint8_t* data,
+                  size_t len) const;
+
+private:
+    struct NodeEntry {
+        SimulatedLinkLayer* link;
+        const SimulatedLocationProvider* location;
+        RadioConfig cfg;
+    };
+
+    static float computeRssiDbm(float tx_power_dbm, float distance_m, float carrier_freq_mhz);
+    static float computeSnrDb(float rssi_dbm, float noise_floor_dbm);
+
+    float carrier_freq_mhz_;
+    mutable std::mutex mutex_;
+    std::unordered_map<uint16_t, NodeEntry> nodes_;
+};

--- a/simulation/include/simulation_builder.h
+++ b/simulation/include/simulation_builder.h
@@ -9,6 +9,7 @@
 #include "config_loader.h"
 #include "simulation_clock.h"
 #include "simulation_config.h"
+#include "simulation_metrics.h"
 #include "simulated_link_layer.h"
 #include "simulated_location_provider.h"
 #include "simulated_network.h"
@@ -89,6 +90,11 @@ public:
 
     /** @brief Sorted list of node ids in this scenario. */
     std::vector<uint16_t> nodeIds() const;
+
+    /** @brief Read-only metrics snapshot for the current virtual time. */
+    SimulationMetricsSnapshot metrics() const;
+    /** @brief Reset scenario metrics counters at current virtual time. */
+    void resetMetrics();
 
 private:
     struct NodeRuntime;

--- a/simulation/include/simulation_builder.h
+++ b/simulation/include/simulation_builder.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "config_loader.h"
+#include "simulation_clock.h"
+#include "simulation_config.h"
+#include "simulated_link_layer.h"
+#include "simulated_location_provider.h"
+#include "simulated_network.h"
+
+class NetworkManager;
+
+/**
+ * @file simulation_builder.h
+ * @ingroup sim_runtime
+ * @brief Scenario orchestration and fluent builder APIs for host simulation.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief Runtime container for a fully built simulation scenario.
+ *
+ * A scenario owns all per-node runtime objects (location providers, simulated
+ * links, network managers), a shared simulated channel, and a deterministic
+ * virtual clock. Progression is controlled manually through @ref step.
+ */
+class SimulationScenario {
+public:
+    /**
+     * @brief Construct and wire node runtimes from configuration.
+     * @throws std::runtime_error If duplicate node ids are present.
+     */
+    explicit SimulationScenario(const SimulationConfig& config);
+    ~SimulationScenario();
+
+    SimulationScenario(const SimulationScenario&) = delete;
+    SimulationScenario& operator=(const SimulationScenario&) = delete;
+
+    /** @brief Start all node managers (idempotent). */
+    void start();
+    /** @brief Stop all node managers (idempotent). */
+    void stop();
+
+    /**
+     * @brief Advance virtual time and update node kinematics.
+     * @param delta_ms Milliseconds to advance.
+     */
+    void step(uint64_t delta_ms);
+
+    /** @brief Number of nodes in the scenario. */
+    size_t deviceCount() const;
+
+    /** @brief Mutable access to scenario virtual clock. */
+    SimulationClock& clock();
+    /** @brief Const access to scenario virtual clock. */
+    const SimulationClock& clock() const;
+
+    /** @brief Mutable access to shared simulated channel. */
+    SimulatedNetwork& network();
+    /** @brief Const access to shared simulated channel. */
+    const SimulatedNetwork& network() const;
+
+    /**
+     * @brief Lookup node manager by node id.
+     * @return Pointer to manager, or @c nullptr if node is missing.
+     */
+    NetworkManager* manager(uint16_t node_id);
+    /**
+     * @brief Const lookup node manager by node id.
+     * @return Pointer to manager, or @c nullptr if node is missing.
+     */
+    const NetworkManager* manager(uint16_t node_id) const;
+
+    /**
+     * @brief Lookup node location provider by node id.
+     * @return Pointer to provider, or @c nullptr if node is missing.
+     */
+    SimulatedLocationProvider* locationProvider(uint16_t node_id);
+    /**
+     * @brief Const lookup node location provider by node id.
+     * @return Pointer to provider, or @c nullptr if node is missing.
+     */
+    const SimulatedLocationProvider* locationProvider(uint16_t node_id) const;
+
+    /** @brief Sorted list of node ids in this scenario. */
+    std::vector<uint16_t> nodeIds() const;
+
+private:
+    struct NodeRuntime;
+
+    void applyDueWaypoints(NodeRuntime& node);
+
+    SimulationClock clock_;
+    SimulatedNetwork network_;
+    bool started_{false};
+    std::unordered_map<uint16_t, std::unique_ptr<NodeRuntime>> nodes_;
+};
+
+/**
+ * @ingroup sim_api
+ * @brief Fluent builder for constructing @ref SimulationScenario instances.
+ *
+ * The builder supports programmatic scenario composition and file-driven
+ * loading through @ref ConfigLoader. Build-time validation guarantees that at
+ * least one node exists before runtime objects are instantiated.
+ */
+class SimulationBuilder {
+public:
+    /** @brief Construct builder with default runtime config values. */
+    SimulationBuilder();
+
+    /** @brief Set radio carrier frequency in MHz. */
+    SimulationBuilder& setCarrierFrequencyMhz(float freq_mhz);
+    /** @brief Set initial simulation clock value in whole seconds. */
+    SimulationBuilder& setStartTimeSeconds(uint32_t start_time_s);
+    /** @brief Set shared network-manager runtime capacities. */
+    SimulationBuilder& setNetworkConfig(const NetworkConfig& cfg);
+
+    /**
+     * @brief Add or replace a device config by node id.
+     * @param cfg Device definition.
+     */
+    SimulationBuilder& addDevice(const SimulationDeviceConfig& cfg);
+    /**
+     * @brief Add a waypoint to an existing device.
+     * @throws std::runtime_error If @p node_id does not exist in current config.
+     */
+    SimulationBuilder& addWaypoint(uint16_t node_id, const SimulationWaypointConfig& waypoint);
+
+    /** @brief Replace current config from a parsed config file. */
+    SimulationBuilder& loadConfigFile(const std::string& file_path);
+    /** @brief Replace current config object wholesale. */
+    SimulationBuilder& setConfig(const SimulationConfig& cfg);
+
+    /**
+     * @brief Materialize a runnable simulation scenario.
+     * @throws std::runtime_error If config has no devices.
+     */
+    std::unique_ptr<SimulationScenario> build() const;
+
+    /** @brief Read current builder config snapshot. */
+    const SimulationConfig& config() const;
+
+private:
+    SimulationConfig config_;
+};

--- a/simulation/include/simulation_clock.h
+++ b/simulation/include/simulation_clock.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+/**
+ * @file simulation_clock.h
+ * @ingroup sim_runtime
+ * @brief Deterministic virtual clock used by simulation stepping.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief Monotonic simulation time source in milliseconds.
+ *
+ * The clock is explicitly advanced by test code or demo loops using @ref step,
+ * enabling deterministic replay and eliminating host wall-time jitter from
+ * scenario progression.
+ */
+class SimulationClock {
+public:
+    SimulationClock() = default;
+
+    /**
+     * @brief Set the current simulation time.
+     * @param now_ms Absolute virtual time in milliseconds.
+     */
+    void reset(uint64_t now_ms = 0);
+
+    /**
+     * @brief Advance virtual time by a delta.
+     * @param delta_ms Milliseconds to add.
+     */
+    void step(uint64_t delta_ms);
+
+    /** @brief Current virtual time in milliseconds. */
+    uint64_t nowMs() const;
+
+    /** @brief Current virtual time in whole seconds. */
+    uint32_t nowSeconds() const;
+
+private:
+    std::atomic<uint64_t> now_ms_{0};
+};

--- a/simulation/include/simulation_config.h
+++ b/simulation/include/simulation_config.h
@@ -51,10 +51,57 @@ struct SimulationDeviceConfig {
  * @brief Runtime-level parameters shared by all nodes in a scenario.
  */
 struct SimulationRuntimeConfig {
+    /** Packet error model selection for SNR-based reception success. */
+    enum class PerModel : uint8_t {
+        Disabled = 0,
+        Threshold = 1,
+        Logistic = 2,
+    };
+
     /** Carrier frequency in MHz for free-space path-loss calculations. */
     float carrier_freq_mhz{868.0f};
     /** Initial simulation wall-clock value in seconds. */
     uint32_t start_time_s{0};
+    /** Deterministic seed for simulation randomness features. */
+    uint64_t random_seed{1};
+    /** Keep legacy immediate delivery semantics when true. */
+    bool compatibility_immediate_delivery{true};
+    /** Target data rate used by timed channel models (future phases). */
+    uint32_t data_rate_bps{50000};
+    /** CSMA slot duration in microseconds (future phases). */
+    uint32_t slot_time_us{1000};
+    /** DIFS guard interval in microseconds (future phases). */
+    uint32_t difs_us{0};
+    /** Minimum contention window (future phases). */
+    uint16_t cw_min{3};
+    /** Maximum contention window (future phases). */
+    uint16_t cw_max{1023};
+    /** Maximum retry count for contention/backoff (future phases). */
+    uint8_t max_retries{4};
+    /** Standard deviation of fading term in dB (future phases). */
+    float fading_stddev_db{0.0f};
+    /** Extra jitter term in dB applied before PER decisions (future phases). */
+    float noise_jitter_db{0.0f};
+    /** PER model mode used after RSSI/sensitivity checks. */
+    PerModel per_model{PerModel::Disabled};
+    /** SNR threshold used by threshold PER mode. */
+    float snr_threshold_db{-200.0f};
+    /** Logistic slope parameter for logistic PER mode. */
+    float per_logistic_k{1.0f};
+    /** Logistic midpoint SNR (dB) for logistic PER mode. */
+    float per_logistic_mid_db{0.0f};
+    /** Minimum propagation delay clamp in microseconds (future phases). */
+    uint32_t propagation_min_delay_us{0};
+    /** Toggle collision model once implemented. */
+    bool enable_collision_model{false};
+    /** Toggle utilization-based congestion drops once implemented. */
+    bool enable_congestion_drops{false};
+    /** Utilization threshold (percentage) above which congestion drops may apply. */
+    float congestion_utilization_threshold_pct{95.0f};
+    /** Probability [0,1] of congestion drop when threshold is exceeded. */
+    float congestion_drop_probability{0.0f};
+    /** Minimum elapsed virtual-time window before congestion checks are active. */
+    uint32_t congestion_min_elapsed_us{1000};
     /** Network-layer queue and duplicate-filter capacities for all managers. */
     NetworkConfig network_config{64, 8, 16};
 };

--- a/simulation/include/simulation_config.h
+++ b/simulation/include/simulation_config.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "network_manager.h"
+#include "simulated_network.h"
+
+/**
+ * @file simulation_config.h
+ * @ingroup sim_config
+ * @brief Scenario configuration structures used by builder and file parser paths.
+ */
+
+/**
+ * @ingroup sim_config
+ * @brief Waypoint state to apply to a device when simulation clock reaches @ref at_s.
+ */
+struct SimulationWaypointConfig {
+    /** Waypoint activation time in whole seconds. */
+    uint32_t at_s{0};
+    /** Target geodetic position in fixed-point degrees (deg * 1e7). */
+    GeoPoint position{0, 0};
+    /** Target speed in centimeters per second after activation. */
+    uint16_t speed_cm_s{0};
+    /** Target heading in centi-degrees, where 0 is north and 9000 is east. */
+    uint16_t heading_cdeg{0};
+};
+
+/**
+ * @ingroup sim_config
+ * @brief Device-level scenario definition for one simulated node.
+ */
+struct SimulationDeviceConfig {
+    /** Unique node identifier used by NetworkManager and simulated radio fan-out. */
+    uint16_t node_id{0};
+    /** Initial geodetic position in fixed-point degrees (deg * 1e7). */
+    GeoPoint initial_position{0, 0};
+    /** Initial speed in centimeters per second. */
+    uint16_t speed_cm_s{0};
+    /** Initial heading in centi-degrees. */
+    uint16_t heading_cdeg{0};
+    /** Per-node radio profile used by SimulatedNetwork propagation checks. */
+    SimulatedNetwork::RadioConfig radio{};
+    /** Optional ordered motion updates applied during stepping. */
+    std::vector<SimulationWaypointConfig> waypoints;
+};
+
+/**
+ * @ingroup sim_config
+ * @brief Runtime-level parameters shared by all nodes in a scenario.
+ */
+struct SimulationRuntimeConfig {
+    /** Carrier frequency in MHz for free-space path-loss calculations. */
+    float carrier_freq_mhz{868.0f};
+    /** Initial simulation wall-clock value in seconds. */
+    uint32_t start_time_s{0};
+    /** Network-layer queue and duplicate-filter capacities for all managers. */
+    NetworkConfig network_config{64, 8, 16};
+};
+
+/**
+ * @ingroup sim_api
+ * @brief Full simulation scenario definition consumed by @ref SimulationBuilder.
+ */
+struct SimulationConfig {
+    /** Shared runtime parameters. */
+    SimulationRuntimeConfig runtime{};
+    /** All nodes that participate in the scenario. */
+    std::vector<SimulationDeviceConfig> devices;
+};

--- a/simulation/include/simulation_docs.h
+++ b/simulation/include/simulation_docs.h
@@ -1,0 +1,57 @@
+#pragma once
+
+/**
+ * @file simulation_docs.h
+ * @brief Doxygen group definitions for the host simulation subsystem.
+ *
+ * This header is documentation-only and is not required by runtime code.
+ */
+
+/**
+ * @defgroup sim Host Simulation
+ * @brief Deterministic host runtime used to exercise the network layer without ESP-IDF.
+ *
+ * The simulation subsystem composes portable network-layer components with host adapters:
+ * - @ref SimulationClock for virtual time.
+ * - @ref SimulatedLocationProvider for deterministic node kinematics.
+ * - @ref SimulatedNetwork for radio propagation and fan-out.
+ * - @ref SimulatedLinkLayer for link-layer bridging to @ref NetworkManager.
+ * - @ref SimulationBuilder and @ref SimulationScenario for scenario composition.
+ * - @ref ConfigLoader for strict file-driven scenario loading.
+ */
+
+/**
+ * @defgroup sim_api Simulation Public API
+ * @ingroup sim
+ * @brief Public API used by simulation applications and tests.
+ */
+
+/**
+ * @defgroup sim_config Simulation Configuration Model
+ * @ingroup sim
+ * @brief Data structures and parser used to define devices, runtime, and waypoints.
+ */
+
+/**
+ * @defgroup sim_runtime Simulation Runtime Orchestration
+ * @ingroup sim
+ * @brief Scenario lifecycle, stepping, node runtime composition, and time progression.
+ */
+
+/**
+ * @defgroup sim_channel Simulated Radio Channel
+ * @ingroup sim
+ * @brief Host radio model implementing path loss, sensitivity checks, and SNR computation.
+ */
+
+/**
+ * @defgroup sim_internal Simulation Internal Notes
+ * @ingroup sim
+ * @brief Internal behavior notes, processing stages, and implementation details.
+ */
+
+/**
+ * @defgroup sim_test Simulation Test Utilities
+ * @ingroup sim
+ * @brief Test harness APIs used by phase 3/4/5 simulation test binaries.
+ */

--- a/simulation/include/simulation_event_queue.h
+++ b/simulation/include/simulation_event_queue.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+/**
+ * @file simulation_event_queue.h
+ * @ingroup sim_runtime
+ * @brief Deterministic time-ordered event queue for host simulation runtime.
+ */
+
+/**
+ * @ingroup sim_runtime
+ * @brief Event categories reserved for simulation runtime scheduling.
+ */
+enum class SimEventType : uint8_t {
+    TxStart = 0,
+    TxEnd = 1,
+    RetryBackoff = 2,
+    RxDelivery = 3,
+};
+
+/**
+ * @ingroup sim_runtime
+ * @brief Generic deterministic event record stored in @ref SimulationEventQueue.
+ */
+struct SimEvent {
+    /** Event timestamp in virtual microseconds. */
+    uint64_t time_us{0};
+    /** Secondary ordering key at equal timestamp; lower value executes first. */
+    uint8_t priority{0};
+    /** Monotonic tie-breaker to keep ordering stable across runs. */
+    uint64_t sequence_id{0};
+    /** Event kind. */
+    SimEventType type{SimEventType::RxDelivery};
+
+    /** Optional source node context. */
+    uint16_t src_node_id{0};
+    /** Optional destination node context. */
+    uint16_t dst_id{0};
+    /** Transmission identity linking start/end/delivery events. */
+    uint64_t tx_id{0};
+    /** Retry/defer attempt count for MAC scheduling flows. */
+    uint8_t retry_count{0};
+    /** Payload bytes for queued delivery-like events. */
+    std::vector<uint8_t> payload;
+};
+
+/**
+ * @ingroup sim_runtime
+ * @brief Thread-safe deterministic min-heap event queue.
+ */
+class SimulationEventQueue {
+public:
+    /** @brief Insert an event into the queue. */
+    void push(const SimEvent& event);
+    /** @brief Insert an event into the queue (move overload). */
+    void push(SimEvent&& event);
+
+    /** @brief Pop next event with time <= @p horizon_us, returns false if none are due. */
+    bool popDue(uint64_t horizon_us, SimEvent& out_event);
+
+    /** @brief Number of pending events in the queue. */
+    size_t size() const;
+    /** @brief Remove all events from the queue. */
+    void clear();
+
+private:
+    struct EventCompare {
+        bool operator()(const SimEvent& lhs, const SimEvent& rhs) const;
+    };
+
+    mutable std::mutex mutex_;
+    std::priority_queue<SimEvent, std::vector<SimEvent>, EventCompare> queue_;
+};

--- a/simulation/include/simulation_metrics.h
+++ b/simulation/include/simulation_metrics.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+
+/**
+ * @file simulation_metrics.h
+ * @ingroup sim_runtime
+ * @brief Simulation metrics snapshot and collection helpers.
+ */
+
+/**
+ * @ingroup sim_api
+ * @brief Aggregated simulation metrics snapshot.
+ */
+struct SimulationMetricsSnapshot {
+    uint64_t tx_attempts{0};
+    uint64_t tx_success{0};
+    uint64_t tx_fail_collision{0};
+    uint64_t tx_fail_per{0};
+    uint64_t retransmissions{0};
+    uint64_t rx_delivered{0};
+    uint64_t rx_dropped{0};
+
+    double packet_delivery_ratio{0.0};
+    double average_latency_ms{0.0};
+    double channel_utilization_pct{0.0};
+};
+
+/**
+ * @ingroup sim_internal
+ * @brief Thread-safe accumulator for simulation metrics.
+ */
+class SimulationMetricsCollector {
+public:
+    /** @brief Reset all counters and set baseline time. */
+    void reset(uint64_t now_us = 0);
+
+    /** @brief Count one transmit attempt. */
+    void onTxAttempt();
+    /** @brief Count transmit outcome as success/failure. */
+    void onTxOutcome(bool success);
+    /** @brief Count one retransmission/defer attempt. */
+    void onRetransmission();
+    /** @brief Count one collision-driven transmit failure. */
+    void onTxCollisionFailure();
+    /** @brief Count one PER-driven transmit failure. */
+    void onTxPerFailure();
+    /** @brief Count one delivered receive event with measured latency. */
+    void onRxDelivered(uint64_t latency_us);
+    /** @brief Count one dropped receive event. */
+    void onRxDropped();
+    /** @brief Add busy-time contribution in microseconds. */
+    void addChannelBusyTime(uint64_t busy_us);
+
+    /** @brief Materialize a read-only metrics snapshot. */
+    SimulationMetricsSnapshot snapshot(uint64_t sim_now_us) const;
+
+private:
+    mutable std::mutex mutex_;
+    uint64_t start_time_us_{0};
+    uint64_t tx_attempts_{0};
+    uint64_t tx_success_{0};
+    uint64_t tx_fail_collision_{0};
+    uint64_t tx_fail_per_{0};
+    uint64_t retransmissions_{0};
+    uint64_t rx_delivered_{0};
+    uint64_t rx_dropped_{0};
+    uint64_t total_latency_us_{0};
+    uint64_t channel_busy_us_{0};
+};

--- a/simulation/src/config_loader.cpp
+++ b/simulation/src/config_loader.cpp
@@ -1,0 +1,446 @@
+#include "config_loader.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+/**
+ * @file config_loader.cpp
+ * @ingroup sim_internal
+ * @brief Internal parser pipeline for the simulation YAML-like configuration format.
+ *
+ * Parsing is intentionally strict and deterministic:
+ * 1. Preprocess strips comments/blank lines and validates indentation multiples.
+ * 2. The top-level parser validates section structure (`runtime`, `devices`).
+ * 3. Field-level converters perform type/range checking and report line errors.
+ * 4. Device waypoint lists are normalized and sorted by activation timestamp.
+ */
+
+namespace {
+
+struct ParsedLine {
+    size_t line_no;
+    size_t indent;
+    std::string text;
+};
+
+std::string trim(const std::string& value)
+{
+    size_t first = 0;
+    while (first < value.size() && std::isspace(static_cast<unsigned char>(value[first]))) {
+        ++first;
+    }
+
+    size_t last = value.size();
+    while (last > first && std::isspace(static_cast<unsigned char>(value[last - 1]))) {
+        --last;
+    }
+
+    return value.substr(first, last - first);
+}
+
+bool startsWith(const std::string& text, const std::string& prefix)
+{
+    return text.size() >= prefix.size() && text.compare(0, prefix.size(), prefix) == 0;
+}
+
+[[noreturn]] void parseError(size_t line_no, const std::string& message)
+{
+    throw std::runtime_error("Config parse error at line " +
+                             std::to_string(static_cast<unsigned long long>(line_no)) +
+                             ": " + message);
+}
+
+std::pair<std::string, std::string> splitKeyValue(const ParsedLine& line)
+{
+    const size_t pos = line.text.find(':');
+    if (pos == std::string::npos) {
+        parseError(line.line_no, "expected key: value pair");
+    }
+
+    const std::string key = trim(line.text.substr(0, pos));
+    const std::string value = trim(line.text.substr(pos + 1));
+    if (key.empty()) {
+        parseError(line.line_no, "empty key is not allowed");
+    }
+
+    return {key, value};
+}
+
+bool isSectionLine(const ParsedLine& line)
+{
+    return !line.text.empty() && line.text.back() == ':' && line.text.find(':') == line.text.size() - 1;
+}
+
+long long parseInteger(const ParsedLine& line, const std::string& raw)
+{
+    if (raw.empty()) {
+        parseError(line.line_no, "missing integer value");
+    }
+
+    size_t consumed = 0;
+    long long v = 0;
+    try {
+        v = std::stoll(raw, &consumed, 10);
+    } catch (const std::exception&) {
+        parseError(line.line_no, "invalid integer value '" + raw + "'");
+    }
+
+    if (consumed != raw.size()) {
+        parseError(line.line_no, "invalid trailing characters in integer value '" + raw + "'");
+    }
+
+    return v;
+}
+
+unsigned long long parseUnsignedInteger(const ParsedLine& line, const std::string& raw)
+{
+    if (raw.empty()) {
+        parseError(line.line_no, "missing integer value");
+    }
+
+    size_t consumed = 0;
+    unsigned long long v = 0;
+    try {
+        v = std::stoull(raw, &consumed, 10);
+    } catch (const std::exception&) {
+        parseError(line.line_no, "invalid unsigned integer value '" + raw + "'");
+    }
+
+    if (consumed != raw.size()) {
+        parseError(line.line_no,
+                   "invalid trailing characters in unsigned integer value '" + raw + "'");
+    }
+
+    return v;
+}
+
+float parseFloat(const ParsedLine& line, const std::string& raw)
+{
+    if (raw.empty()) {
+        parseError(line.line_no, "missing float value");
+    }
+
+    size_t consumed = 0;
+    float v = 0.0f;
+    try {
+        v = std::stof(raw, &consumed);
+    } catch (const std::exception&) {
+        parseError(line.line_no, "invalid float value '" + raw + "'");
+    }
+
+    if (consumed != raw.size()) {
+        parseError(line.line_no, "invalid trailing characters in float value '" + raw + "'");
+    }
+
+    return v;
+}
+
+template <typename TInt>
+TInt parseUnsigned(const ParsedLine& line, const std::string& raw, const char* label)
+{
+    const unsigned long long v = parseUnsignedInteger(line, raw);
+    if (v > static_cast<unsigned long long>(std::numeric_limits<TInt>::max())) {
+        parseError(line.line_no,
+                   std::string(label) + " is out of range: " + raw);
+    }
+    return static_cast<TInt>(v);
+}
+
+template <typename TInt>
+TInt parseSigned(const ParsedLine& line, const std::string& raw, const char* label)
+{
+    const long long v = parseInteger(line, raw);
+    if (v < static_cast<long long>(std::numeric_limits<TInt>::min()) ||
+        v > static_cast<long long>(std::numeric_limits<TInt>::max())) {
+        parseError(line.line_no,
+                   std::string(label) + " is out of range: " + raw);
+    }
+    return static_cast<TInt>(v);
+}
+
+std::vector<ParsedLine> preprocess(const std::string& text)
+{
+    std::vector<ParsedLine> lines;
+
+    std::istringstream input(text);
+    std::string raw;
+    size_t line_no = 0;
+
+    while (std::getline(input, raw)) {
+        ++line_no;
+
+        const size_t comment_pos = raw.find('#');
+        if (comment_pos != std::string::npos) {
+            raw = raw.substr(0, comment_pos);
+        }
+
+        const std::string stripped = trim(raw);
+        if (stripped.empty()) {
+            continue;
+        }
+
+        size_t indent = 0;
+        while (indent < raw.size() && raw[indent] == ' ') {
+            ++indent;
+        }
+
+        if (indent > 0 && indent % 2 != 0) {
+            parseError(line_no, "indentation must use multiples of 2 spaces");
+        }
+
+        lines.push_back(ParsedLine{line_no, indent, stripped});
+    }
+
+    return lines;
+}
+
+void setRuntimeField(SimulationRuntimeConfig& runtime, const ParsedLine& line)
+{
+    const auto [key, value] = splitKeyValue(line);
+    if (isSectionLine(line) || value.empty()) {
+        parseError(line.line_no, "runtime field must be 'key: value'");
+    }
+
+    if (key == "carrier_freq_mhz") {
+        runtime.carrier_freq_mhz = parseFloat(line, value);
+    } else if (key == "start_time_s") {
+        runtime.start_time_s = parseUnsigned<uint32_t>(line, value, "start_time_s");
+    } else if (key == "duplicate_cache_size") {
+        runtime.network_config.duplicate_cache_size =
+            parseUnsigned<size_t>(line, value, "duplicate_cache_size");
+    } else if (key == "forwarding_queue_size") {
+        runtime.network_config.forwarding_queue_size =
+            parseUnsigned<size_t>(line, value, "forwarding_queue_size");
+    } else if (key == "rx_queue_depth") {
+        runtime.network_config.rx_queue_depth =
+            parseUnsigned<size_t>(line, value, "rx_queue_depth");
+    } else {
+        parseError(line.line_no, "unknown runtime field '" + key + "'");
+    }
+}
+
+void setDeviceField(SimulationDeviceConfig& device,
+                    bool& has_node_id,
+                    const ParsedLine& line,
+                    const std::string& key,
+                    const std::string& value)
+{
+    if (key == "id" || key == "node_id") {
+        device.node_id = parseUnsigned<uint16_t>(line, value, "device id");
+        has_node_id = true;
+    } else if (key == "lat" || key == "initial_lat") {
+        device.initial_position.lat = parseSigned<int32_t>(line, value, "lat");
+    } else if (key == "lon" || key == "initial_lon") {
+        device.initial_position.lon = parseSigned<int32_t>(line, value, "lon");
+    } else if (key == "speed_cm_s") {
+        device.speed_cm_s = parseUnsigned<uint16_t>(line, value, "speed_cm_s");
+    } else if (key == "heading_cdeg") {
+        device.heading_cdeg = parseUnsigned<uint16_t>(line, value, "heading_cdeg");
+    } else if (key == "tx_power_dbm") {
+        device.radio.tx_power_dbm = parseFloat(line, value);
+    } else if (key == "noise_floor_dbm") {
+        device.radio.noise_floor_dbm = parseFloat(line, value);
+    } else if (key == "sensitivity_dbm") {
+        device.radio.sensitivity_dbm = parseFloat(line, value);
+    } else {
+        parseError(line.line_no, "unknown device field '" + key + "'");
+    }
+}
+
+void setWaypointField(SimulationWaypointConfig& waypoint,
+                      const ParsedLine& line,
+                      const std::string& key,
+                      const std::string& value)
+{
+    if (key == "at_s") {
+        waypoint.at_s = parseUnsigned<uint32_t>(line, value, "at_s");
+    } else if (key == "lat") {
+        waypoint.position.lat = parseSigned<int32_t>(line, value, "lat");
+    } else if (key == "lon") {
+        waypoint.position.lon = parseSigned<int32_t>(line, value, "lon");
+    } else if (key == "speed_cm_s") {
+        waypoint.speed_cm_s = parseUnsigned<uint16_t>(line, value, "speed_cm_s");
+    } else if (key == "heading_cdeg") {
+        waypoint.heading_cdeg = parseUnsigned<uint16_t>(line, value, "heading_cdeg");
+    } else {
+        parseError(line.line_no, "unknown waypoint field '" + key + "'");
+    }
+}
+
+size_t parseWaypointsBlock(const std::vector<ParsedLine>& lines,
+                           size_t index,
+                           size_t list_indent,
+                           SimulationDeviceConfig& device)
+{
+    while (index < lines.size()) {
+        const ParsedLine& line = lines[index];
+        if (line.indent < list_indent) {
+            break;
+        }
+
+        if (line.indent != list_indent || !startsWith(line.text, "-")) {
+            parseError(line.line_no, "expected waypoint list item '- ...'");
+        }
+
+        SimulationWaypointConfig waypoint;
+        std::string inline_content = trim(line.text.substr(1));
+        if (!inline_content.empty()) {
+            ParsedLine inline_line{line.line_no, line.indent, inline_content};
+            const auto [k, v] = splitKeyValue(inline_line);
+            if (v.empty()) {
+                parseError(line.line_no, "waypoint list item must use '- key: value'");
+            }
+            setWaypointField(waypoint, inline_line, k, v);
+        }
+
+        ++index;
+        while (index < lines.size() && lines[index].indent > list_indent) {
+            const ParsedLine& child = lines[index];
+            if (child.indent != list_indent + 2) {
+                parseError(child.line_no, "unexpected waypoint indentation");
+            }
+
+            const auto [k, v] = splitKeyValue(child);
+            if (v.empty()) {
+                parseError(child.line_no, "waypoint field must be 'key: value'");
+            }
+            setWaypointField(waypoint, child, k, v);
+            ++index;
+        }
+
+        device.waypoints.push_back(waypoint);
+    }
+
+    return index;
+}
+
+size_t parseDeviceBlock(const std::vector<ParsedLine>& lines,
+                        size_t index,
+                        size_t item_indent,
+                        SimulationDeviceConfig& device)
+{
+    bool has_node_id = false;
+
+    const ParsedLine& item_line = lines[index];
+    std::string inline_content = trim(item_line.text.substr(1));
+    if (!inline_content.empty()) {
+        ParsedLine inline_line{item_line.line_no, item_line.indent, inline_content};
+        const auto [k, v] = splitKeyValue(inline_line);
+        if (v.empty()) {
+            parseError(item_line.line_no, "device list item must use '- key: value'");
+        }
+        setDeviceField(device, has_node_id, inline_line, k, v);
+    }
+
+    ++index;
+    while (index < lines.size() && lines[index].indent > item_indent) {
+        const ParsedLine& line = lines[index];
+        if (line.indent != item_indent + 2) {
+            parseError(line.line_no, "unexpected device indentation");
+        }
+
+        if (line.text == "waypoints:") {
+            index = parseWaypointsBlock(lines, index + 1, item_indent + 4, device);
+            continue;
+        }
+
+        const auto [k, v] = splitKeyValue(line);
+        if (v.empty()) {
+            parseError(line.line_no, "device field must be 'key: value'");
+        }
+        setDeviceField(device, has_node_id, line, k, v);
+        ++index;
+    }
+
+    if (!has_node_id) {
+        parseError(item_line.line_no, "device id is required");
+    }
+
+    std::sort(device.waypoints.begin(), device.waypoints.end(),
+              [](const SimulationWaypointConfig& a, const SimulationWaypointConfig& b) {
+                  return a.at_s < b.at_s;
+              });
+
+    return index;
+}
+
+SimulationConfig parseLines(const std::vector<ParsedLine>& lines)
+{
+    SimulationConfig cfg;
+
+    bool saw_runtime = false;
+    bool saw_devices = false;
+
+    size_t index = 0;
+    while (index < lines.size()) {
+        const ParsedLine& line = lines[index];
+        if (line.indent != 0) {
+            parseError(line.line_no, "top-level keys must not be indented");
+        }
+
+        if (line.text == "runtime:") {
+            saw_runtime = true;
+            ++index;
+            while (index < lines.size() && lines[index].indent > 0) {
+                if (lines[index].indent != 2) {
+                    parseError(lines[index].line_no, "unexpected runtime indentation");
+                }
+                setRuntimeField(cfg.runtime, lines[index]);
+                ++index;
+            }
+            continue;
+        }
+
+        if (line.text == "devices:") {
+            saw_devices = true;
+            ++index;
+            while (index < lines.size() && lines[index].indent > 0) {
+                if (lines[index].indent != 2 || !startsWith(lines[index].text, "-")) {
+                    parseError(lines[index].line_no, "expected device list item '- ...'");
+                }
+
+                SimulationDeviceConfig device;
+                index = parseDeviceBlock(lines, index, 2, device);
+                cfg.devices.push_back(device);
+            }
+            continue;
+        }
+
+        parseError(line.line_no, "unknown top-level key '" + line.text + "'");
+    }
+
+    if (!saw_runtime) {
+        throw std::runtime_error("Config parse error: missing top-level 'runtime:' section");
+    }
+    if (!saw_devices) {
+        throw std::runtime_error("Config parse error: missing top-level 'devices:' section");
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+SimulationConfig ConfigLoader::loadFromFile(const std::string& file_path)
+{
+    std::ifstream in(file_path);
+    if (!in.is_open()) {
+        throw std::runtime_error("Failed to open config file: " + file_path);
+    }
+
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return parseText(buffer.str());
+}
+
+SimulationConfig ConfigLoader::parseText(const std::string& text)
+{
+    const std::vector<ParsedLine> lines = preprocess(text);
+    return parseLines(lines);
+}

--- a/simulation/src/config_loader.cpp
+++ b/simulation/src/config_loader.cpp
@@ -141,6 +141,36 @@ float parseFloat(const ParsedLine& line, const std::string& raw)
     return v;
 }
 
+bool parseBool(const ParsedLine& line, const std::string& raw)
+{
+    if (raw == "true" || raw == "True" || raw == "1") {
+        return true;
+    }
+
+    if (raw == "false" || raw == "False" || raw == "0") {
+        return false;
+    }
+
+    parseError(line.line_no, "invalid bool value '" + raw + "'");
+}
+
+SimulationRuntimeConfig::PerModel parsePerModel(const ParsedLine& line, const std::string& raw)
+{
+    if (raw == "disabled" || raw == "off") {
+        return SimulationRuntimeConfig::PerModel::Disabled;
+    }
+
+    if (raw == "threshold") {
+        return SimulationRuntimeConfig::PerModel::Threshold;
+    }
+
+    if (raw == "logistic") {
+        return SimulationRuntimeConfig::PerModel::Logistic;
+    }
+
+    parseError(line.line_no, "invalid per_model value '" + raw + "'");
+}
+
 template <typename TInt>
 TInt parseUnsigned(const ParsedLine& line, const std::string& raw, const char* label)
 {
@@ -211,6 +241,48 @@ void setRuntimeField(SimulationRuntimeConfig& runtime, const ParsedLine& line)
         runtime.carrier_freq_mhz = parseFloat(line, value);
     } else if (key == "start_time_s") {
         runtime.start_time_s = parseUnsigned<uint32_t>(line, value, "start_time_s");
+    } else if (key == "random_seed") {
+        runtime.random_seed = parseUnsigned<uint64_t>(line, value, "random_seed");
+    } else if (key == "compatibility_immediate_delivery") {
+        runtime.compatibility_immediate_delivery = parseBool(line, value);
+    } else if (key == "data_rate_bps") {
+        runtime.data_rate_bps = parseUnsigned<uint32_t>(line, value, "data_rate_bps");
+    } else if (key == "slot_time_us") {
+        runtime.slot_time_us = parseUnsigned<uint32_t>(line, value, "slot_time_us");
+    } else if (key == "difs_us") {
+        runtime.difs_us = parseUnsigned<uint32_t>(line, value, "difs_us");
+    } else if (key == "cw_min") {
+        runtime.cw_min = parseUnsigned<uint16_t>(line, value, "cw_min");
+    } else if (key == "cw_max") {
+        runtime.cw_max = parseUnsigned<uint16_t>(line, value, "cw_max");
+    } else if (key == "max_retries") {
+        runtime.max_retries = parseUnsigned<uint8_t>(line, value, "max_retries");
+    } else if (key == "fading_stddev_db") {
+        runtime.fading_stddev_db = parseFloat(line, value);
+    } else if (key == "noise_jitter_db") {
+        runtime.noise_jitter_db = parseFloat(line, value);
+    } else if (key == "per_model") {
+        runtime.per_model = parsePerModel(line, value);
+    } else if (key == "snr_threshold_db") {
+        runtime.snr_threshold_db = parseFloat(line, value);
+    } else if (key == "per_logistic_k") {
+        runtime.per_logistic_k = parseFloat(line, value);
+    } else if (key == "per_logistic_mid_db") {
+        runtime.per_logistic_mid_db = parseFloat(line, value);
+    } else if (key == "propagation_min_delay_us") {
+        runtime.propagation_min_delay_us =
+            parseUnsigned<uint32_t>(line, value, "propagation_min_delay_us");
+    } else if (key == "enable_collision_model") {
+        runtime.enable_collision_model = parseBool(line, value);
+    } else if (key == "enable_congestion_drops") {
+        runtime.enable_congestion_drops = parseBool(line, value);
+    } else if (key == "congestion_utilization_threshold_pct") {
+        runtime.congestion_utilization_threshold_pct = parseFloat(line, value);
+    } else if (key == "congestion_drop_probability") {
+        runtime.congestion_drop_probability = parseFloat(line, value);
+    } else if (key == "congestion_min_elapsed_us") {
+        runtime.congestion_min_elapsed_us =
+            parseUnsigned<uint32_t>(line, value, "congestion_min_elapsed_us");
     } else if (key == "duplicate_cache_size") {
         runtime.network_config.duplicate_cache_size =
             parseUnsigned<size_t>(line, value, "duplicate_cache_size");

--- a/simulation/src/main.cpp
+++ b/simulation/src/main.cpp
@@ -1,0 +1,137 @@
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "network_manager.h"
+#include "simulation_builder.h"
+
+/**
+ * @file main.cpp
+ * @ingroup sim_internal
+ * @brief Demo executable showcasing scenario construction and message flow.
+ *
+ * The demo supports two startup modes:
+ * - Built-in three-node default scenario.
+ * - External scenario loaded from config file argument.
+ */
+
+namespace {
+
+constexpr uint16_t kNodeA = 0x1001;
+constexpr uint16_t kNodeB = 0x1002;
+constexpr uint16_t kNodeC = 0x1003;
+
+std::unique_ptr<SimulationScenario> createDefaultScenario()
+{
+    SimulationBuilder builder;
+
+    builder.setCarrierFrequencyMhz(868.0f)
+        .setStartTimeSeconds(1000)
+        .setNetworkConfig(NetworkConfig{64, 8, 16})
+        .addDevice(SimulationDeviceConfig{
+            kNodeA,
+            GeoPoint{125000000, 773000000},
+            80,
+            9000,
+            SimulatedNetwork::RadioConfig{14.0f, -110.0f, -118.0f},
+            {}})
+        .addDevice(SimulationDeviceConfig{
+            kNodeB,
+            GeoPoint{125005000, 773005000},
+            40,
+            18000,
+            SimulatedNetwork::RadioConfig{14.0f, -110.0f, -118.0f},
+            {}})
+        .addDevice(SimulationDeviceConfig{
+            kNodeC,
+            GeoPoint{125030000, 773030000},
+            0,
+            0,
+            SimulatedNetwork::RadioConfig{14.0f, -110.0f, -118.0f},
+            {}})
+        .addWaypoint(kNodeA,
+                     SimulationWaypointConfig{1002,
+                                              GeoPoint{125001200, 773001500},
+                                              100,
+                                              4500});
+
+    return builder.build();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    try {
+        std::unique_ptr<SimulationScenario> scenario;
+
+        if (argc > 1) {
+            SimulationBuilder builder;
+            const std::string config_path = argv[1];
+            builder.loadConfigFile(config_path);
+            scenario = builder.build();
+            std::printf("Loaded simulation config: %s\n", config_path.c_str());
+        } else {
+            scenario = createDefaultScenario();
+            std::printf("Using built-in default scenario\n");
+        }
+
+        const std::vector<uint16_t> node_ids = scenario->nodeIds();
+        if (node_ids.size() < 2) {
+            std::fprintf(stderr, "Need at least 2 devices in scenario\n");
+            return 2;
+        }
+
+        const uint16_t sender_id = node_ids.front();
+        NetworkManager* sender_mgr = scenario->manager(sender_id);
+        if (!sender_mgr) {
+            std::fprintf(stderr, "Sender node not found\n");
+            return 2;
+        }
+
+        for (size_t i = 1; i < node_ids.size(); ++i) {
+            const uint16_t node_id = node_ids[i];
+            NetworkManager* mgr = scenario->manager(node_id);
+            if (!mgr) {
+                continue;
+            }
+
+            mgr->setAppRxCallback([node_id](const NetworkHeader& hdr,
+                                            const uint8_t* payload,
+                                            size_t len) {
+                std::printf("Node 0x%04x received msg_id=0x%08lx bytes=%zu first=%u\n",
+                            static_cast<unsigned>(node_id),
+                            static_cast<unsigned long>(hdr.message_id),
+                            len,
+                            (len > 0) ? static_cast<unsigned>(payload[0]) : 0U);
+            });
+        }
+
+        scenario->start();
+
+        const uint8_t payload[] = {42, 99, 7};
+        int rc = sender_mgr->sendMessage(Priority::NORMAL,
+                                         PropagationMode::OMNI,
+                                         0,
+                                         3,
+                                         2000,
+                                         30,
+                                         payload,
+                                         sizeof(payload));
+
+        std::printf("Initial send rc=%d\n", rc);
+
+        for (int i = 0; i < 20; ++i) {
+            scenario->step(100);
+        }
+
+        scenario->stop();
+        return 0;
+    } catch (const std::exception& ex) {
+        std::fprintf(stderr, "Simulation failed: %s\n", ex.what());
+        return 1;
+    }
+}

--- a/simulation/src/simulated_link_layer.cpp
+++ b/simulation/src/simulated_link_layer.cpp
@@ -1,0 +1,63 @@
+#include "simulated_link_layer.h"
+
+#include <utility>
+
+#include "simulated_network.h"
+
+/**
+ * @file simulated_link_layer.cpp
+ * @ingroup sim_internal
+ * @brief Internal link adapter implementation for in-memory frame transport.
+ *
+ * The adapter mirrors the runtime contract of ILinkLayer while replacing radio I/O
+ * with direct calls into SimulatedNetwork. Receive callback installation and
+ * dispatch are mutex-protected to support asynchronous manager threads.
+ */
+
+SimulatedLinkLayer::SimulatedLinkLayer(uint16_t node_id, SimulatedNetwork& network)
+    : node_id_(node_id)
+    , network_(network)
+{
+}
+
+SimulatedLinkLayer::~SimulatedLinkLayer()
+{
+    network_.unregisterNode(node_id_);
+}
+
+int SimulatedLinkLayer::send(uint16_t dstId, const uint8_t* data, size_t len)
+{
+    if (!data || len == 0 || len > LORA_MAX_PAYLOAD) {
+        return -1;
+    }
+
+    network_.transmit(node_id_, dstId, data, len);
+    return 0;
+}
+
+void SimulatedLinkLayer::setRxHandler(RxHandler handler)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    handler_ = std::move(handler);
+}
+
+uint16_t SimulatedLinkLayer::getNodeId() const
+{
+    return node_id_;
+}
+
+void SimulatedLinkLayer::deliverFromNetwork(const uint8_t* data,
+                                            size_t len,
+                                            float rssi,
+                                            float snr)
+{
+    RxHandler handler;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        handler = handler_;
+    }
+
+    if (handler) {
+        handler(data, len, rssi, snr);
+    }
+}

--- a/simulation/src/simulated_location_provider.cpp
+++ b/simulation/src/simulated_location_provider.cpp
@@ -1,0 +1,95 @@
+#include "simulated_location_provider.h"
+
+#include <cmath>
+
+/**
+ * @file simulated_location_provider.cpp
+ * @ingroup sim_internal
+ * @brief Internal kinematics integration for simulated node movement.
+ *
+ * Position updates use heading-based north/east decomposition and convert
+ * displacement back to latitude/longitude deltas using a spherical Earth model.
+ * Timestamp progression tracks sub-second accumulation to keep second granularity
+ * consistent with NetworkHeader fields.
+ */
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kEarthRadiusM = 6371000.0;
+
+} // namespace
+
+SimulatedLocationProvider::SimulatedLocationProvider(const Kinematics& initial)
+    : state_(initial)
+{
+}
+
+GeoPoint SimulatedLocationProvider::getLocation() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return state_.position;
+}
+
+uint16_t SimulatedLocationProvider::getSpeed() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return state_.speed_cm_s;
+}
+
+uint16_t SimulatedLocationProvider::getHeading() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return state_.heading_cdeg;
+}
+
+uint32_t SimulatedLocationProvider::getTimestamp() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return state_.timestamp_s;
+}
+
+void SimulatedLocationProvider::setKinematics(const Kinematics& state)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    state_ = state;
+    subsecond_ms_ = 0;
+}
+
+void SimulatedLocationProvider::advance(uint64_t delta_ms)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    uint64_t distance_cm = static_cast<uint64_t>(state_.speed_cm_s) * delta_ms / 1000ULL;
+    double distance_m = static_cast<double>(distance_cm) / 100.0;
+
+    if (distance_m > 0.0) {
+        double heading_deg = static_cast<double>(state_.heading_cdeg) / 100.0;
+        double heading_rad = heading_deg * (kPi / 180.0);
+
+        // 0 degrees is north: split travel into north/east components.
+        double north_m = std::cos(heading_rad) * distance_m;
+        double east_m = std::sin(heading_rad) * distance_m;
+
+        double lat_deg = static_cast<double>(state_.position.lat) / 1e7;
+        double lat_rad = lat_deg * (kPi / 180.0);
+
+        double delta_lat_deg = (north_m / kEarthRadiusM) * (180.0 / kPi);
+        double denom = std::cos(lat_rad);
+        if (std::fabs(denom) < 1e-6) {
+            denom = (denom < 0.0) ? -1e-6 : 1e-6;
+        }
+        double delta_lon_deg = (east_m / (kEarthRadiusM * denom)) * (180.0 / kPi);
+
+        double next_lat = lat_deg + delta_lat_deg;
+        double lon_deg = static_cast<double>(state_.position.lon) / 1e7;
+        double next_lon = lon_deg + delta_lon_deg;
+
+        state_.position.lat = static_cast<int32_t>(std::llround(next_lat * 1e7));
+        state_.position.lon = static_cast<int32_t>(std::llround(next_lon * 1e7));
+    }
+
+    uint64_t total_ms = static_cast<uint64_t>(subsecond_ms_) + delta_ms;
+    state_.timestamp_s += static_cast<uint32_t>(total_ms / 1000ULL);
+    subsecond_ms_ = static_cast<uint16_t>(total_ms % 1000ULL);
+}

--- a/simulation/src/simulated_network.cpp
+++ b/simulation/src/simulated_network.cpp
@@ -24,6 +24,12 @@
 namespace {
 
 constexpr float kMinDistanceM = 1.0f;
+constexpr double kSpeedOfLightMps = 299792458.0;
+constexpr double kInv2Pow53 = 1.0 / 9007199254740992.0; // 2^53
+
+constexpr uint8_t kPerModelDisabled = 0;
+constexpr uint8_t kPerModelThreshold = 1;
+constexpr uint8_t kPerModelLogistic = 2;
 
 struct SnapshotEntry {
     uint16_t node_id;
@@ -34,9 +40,54 @@ struct SnapshotEntry {
 
 } // namespace
 
-SimulatedNetwork::SimulatedNetwork(float carrier_freq_mhz)
+SimulatedNetwork::SimulatedNetwork(float carrier_freq_mhz,
+                                   bool compatibility_immediate_delivery)
     : carrier_freq_mhz_(carrier_freq_mhz)
+    , compatibility_immediate_delivery_(compatibility_immediate_delivery)
 {
+}
+
+void SimulatedNetwork::configureMac(uint32_t data_rate_bps,
+                                    uint32_t slot_time_us,
+                                    uint32_t difs_us,
+                                    uint8_t max_retries,
+                                    uint32_t propagation_min_delay_us,
+                                    uint16_t cw_min,
+                                    uint16_t cw_max,
+                                    uint64_t random_seed,
+                                    bool enable_collision_model,
+                                    uint8_t per_model,
+                                    float snr_threshold_db,
+                                    float per_logistic_k,
+                                    float per_logistic_mid_db,
+                                    float fading_stddev_db,
+                                    float noise_jitter_db,
+                                    bool enable_congestion_drops,
+                                    float congestion_utilization_threshold_pct,
+                                    float congestion_drop_probability,
+                                    uint32_t congestion_min_elapsed_us)
+{
+    data_rate_bps_ = (data_rate_bps == 0) ? 1U : data_rate_bps;
+    slot_time_us_ = slot_time_us;
+    difs_us_ = difs_us;
+    max_retries_ = max_retries;
+    propagation_min_delay_us_ = propagation_min_delay_us;
+    cw_min_ = cw_min;
+    cw_max_ = std::max<uint16_t>(cw_max, cw_min_);
+    random_seed_ = random_seed;
+    enable_collision_model_ = enable_collision_model;
+    per_model_ = per_model;
+    snr_threshold_db_ = snr_threshold_db;
+    per_logistic_k_ = per_logistic_k;
+    per_logistic_mid_db_ = per_logistic_mid_db;
+    fading_stddev_db_ = fading_stddev_db;
+    noise_jitter_db_ = noise_jitter_db;
+    enable_congestion_drops_ = enable_congestion_drops;
+    congestion_utilization_threshold_pct_ =
+        std::max(0.0f, std::min(100.0f, congestion_utilization_threshold_pct));
+    congestion_drop_probability_ =
+        std::max(0.0f, std::min(1.0f, congestion_drop_probability));
+    congestion_min_elapsed_us_ = congestion_min_elapsed_us;
 }
 
 void SimulatedNetwork::registerNode(uint16_t node_id,
@@ -54,12 +105,14 @@ void SimulatedNetwork::registerNode(uint16_t node_id,
 {
     std::lock_guard<std::mutex> lock(mutex_);
     nodes_[node_id] = NodeEntry{link, location, cfg};
+    cw_state_by_node_[node_id] = cw_min_;
 }
 
 void SimulatedNetwork::unregisterNode(uint16_t node_id)
 {
     std::lock_guard<std::mutex> lock(mutex_);
     nodes_.erase(node_id);
+    cw_state_by_node_.erase(node_id);
 }
 
 size_t SimulatedNetwork::nodeCount() const
@@ -71,58 +124,450 @@ size_t SimulatedNetwork::nodeCount() const
 void SimulatedNetwork::transmit(uint16_t src_node_id,
                                 uint16_t dst_id,
                                 const uint8_t* data,
-                                size_t len) const
+                                size_t len)
 {
     if (!data || len == 0 || len > LORA_MAX_PAYLOAD) {
         return;
     }
 
-    SnapshotEntry src{};
-    std::vector<SnapshotEntry> recipients;
+    metrics_.onTxAttempt();
 
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        auto src_it = nodes_.find(src_node_id);
-        if (src_it == nodes_.end()) {
-            return;
-        }
+    SimEvent event;
+    event.time_us = now_us_.load();
+    event.priority = 2;
+    event.sequence_id = nextSequenceId();
+    event.tx_id = nextSequenceId();
+    event.type = compatibility_immediate_delivery_ ? SimEventType::RxDelivery : SimEventType::TxStart;
+    event.src_node_id = src_node_id;
+    event.dst_id = dst_id;
+    event.retry_count = 0;
+    event.payload.assign(data, data + len);
 
-        src = SnapshotEntry{
-            src_node_id,
-            src_it->second.link,
-            src_it->second.location->getLocation(),
-            src_it->second.cfg,
-        };
+    event_queue_.push(std::move(event));
 
-        recipients.reserve(nodes_.size());
-        for (const auto& [node_id, entry] : nodes_) {
-            if (node_id == src_node_id) {
-                continue;
-            }
-            if (dst_id != BROADCAST_ADDR && dst_id != node_id) {
-                continue;
-            }
+    if (compatibility_immediate_delivery_) {
+        processUntil(now_us_.load());
+    }
+}
 
-            recipients.push_back(SnapshotEntry{
-                node_id,
-                entry.link,
-                entry.location->getLocation(),
-                entry.cfg,
-            });
+void SimulatedNetwork::setNowUs(uint64_t now_us)
+{
+    now_us_.store(now_us);
+}
+
+uint64_t SimulatedNetwork::nowUs() const
+{
+    return now_us_.load();
+}
+
+void SimulatedNetwork::processUntil(uint64_t horizon_us)
+{
+    SimEvent event;
+    while (event_queue_.popDue(horizon_us, event)) {
+        now_us_.store(event.time_us);
+        switch (event.type) {
+        case SimEventType::TxStart:
+            executeTxStartEvent(event);
+            break;
+        case SimEventType::TxEnd:
+            executeTxEndEvent(event);
+            break;
+        case SimEventType::RetryBackoff:
+            executeRetryBackoffEvent(event);
+            break;
+        case SimEventType::RxDelivery:
+            executeDeliveryEvent(event);
+            break;
         }
     }
 
-    for (const SnapshotEntry& dst : recipients) {
+    now_us_.store(horizon_us);
+}
+
+SimulationMetricsSnapshot SimulatedNetwork::metricsSnapshot(uint64_t sim_now_us) const
+{
+    return metrics_.snapshot(sim_now_us);
+}
+
+void SimulatedNetwork::resetMetrics(uint64_t now_us)
+{
+    metrics_.reset(now_us);
+    std::lock_guard<std::mutex> lock(mutex_);
+    channel_busy_until_us_ = now_us;
+    channel_busy_accumulated_us_ = 0;
+    utilization_start_time_us_ = now_us;
+    active_transmissions_.clear();
+    tx_delivery_state_.clear();
+    for (auto& [node_id, cw_current] : cw_state_by_node_) {
+        (void)node_id;
+        cw_current = cw_min_;
+    }
+}
+
+void SimulatedNetwork::executeTxStartEvent(const SimEvent& event)
+{
+    const uint64_t tx_start_us = event.time_us;
+    const uint64_t tx_duration_us = computeTxDurationUs(event.payload.size());
+    const uint64_t tx_end_us = tx_start_us + tx_duration_us;
+
+    uint64_t busy_until_snapshot = 0;
+    bool allow_collision_start = false;
+    std::vector<std::pair<uint16_t, float>> recipients;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto src_it = nodes_.find(event.src_node_id);
+        if (src_it == nodes_.end()) {
+            metrics_.onTxOutcome(false);
+            return;
+        }
+
+        const GeoPoint src_location = src_it->second.location->getLocation();
+        recipients.reserve(nodes_.size());
+        for (const auto& [node_id, entry] : nodes_) {
+            if (node_id == event.src_node_id) {
+                continue;
+            }
+            if (event.dst_id != BROADCAST_ADDR && event.dst_id != node_id) {
+                continue;
+            }
+
+            float distance_m = geo::haversine_m(src_location, entry.location->getLocation());
+            distance_m = std::max(distance_m, kMinDistanceM);
+            recipients.emplace_back(node_id, distance_m);
+        }
+
+        busy_until_snapshot = channel_busy_until_us_;
+
+        if (tx_start_us < busy_until_snapshot && enable_collision_model_ && event.retry_count == 0) {
+            for (const auto& [active_tx_id, active_tx] : active_transmissions_) {
+                (void)active_tx_id;
+                if (active_tx.start_us == tx_start_us && active_tx.end_us > tx_start_us) {
+                    allow_collision_start = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (tx_start_us < busy_until_snapshot && !allow_collision_start) {
+        if (event.retry_count >= max_retries_) {
+            metrics_.onTxOutcome(false);
+            return;
+        }
+
+        uint16_t next_cw = cw_min_;
+        uint64_t backoff_slots = 0;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            const uint16_t current_cw = getOrInitCwState(event.src_node_id);
+            next_cw = static_cast<uint16_t>(std::min<uint32_t>(
+                static_cast<uint32_t>(cw_max_),
+                static_cast<uint32_t>(current_cw) * 2U + 1U));
+            cw_state_by_node_[event.src_node_id] = next_cw;
+            backoff_slots = computeBackoffSlots(event.src_node_id,
+                                                event.retry_count,
+                                                event.tx_id,
+                                                next_cw);
+        }
+
+        SimEvent retry = event;
+        retry.type = SimEventType::RetryBackoff;
+        retry.time_us = busy_until_snapshot + difs_us_ + backoff_slots * slot_time_us_;
+        retry.priority = 1;
+        retry.retry_count = static_cast<uint8_t>(event.retry_count + 1);
+        retry.sequence_id = nextSequenceId();
+
+        metrics_.onRetransmission();
+        event_queue_.push(std::move(retry));
+        return;
+    }
+
+    bool tx_collided = false;
+    std::vector<uint64_t> overlapped_tx_ids;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (enable_collision_model_) {
+            for (const auto& [active_tx_id, active_tx] : active_transmissions_) {
+                if (tx_start_us < active_tx.end_us && tx_end_us > active_tx.start_us) {
+                    overlapped_tx_ids.push_back(active_tx_id);
+                }
+            }
+
+            if (!overlapped_tx_ids.empty()) {
+                tx_collided = true;
+                for (uint64_t active_tx_id : overlapped_tx_ids) {
+                    auto it = active_transmissions_.find(active_tx_id);
+                    if (it != active_transmissions_.end()) {
+                        it->second.collided = true;
+                    }
+
+                    auto state_it = tx_delivery_state_.find(active_tx_id);
+                    if (state_it != tx_delivery_state_.end()) {
+                        state_it->second.collided = true;
+                    }
+                }
+            }
+        }
+
+        if (tx_end_us > channel_busy_until_us_) {
+            channel_busy_until_us_ = tx_end_us;
+        }
+
+        channel_busy_accumulated_us_ += tx_duration_us;
+
+        active_transmissions_[event.tx_id] = ActiveTransmission{
+            event.tx_id,
+            event.src_node_id,
+            tx_start_us,
+            tx_end_us,
+            tx_collided,
+        };
+        tx_delivery_state_[event.tx_id] = TxDeliveryState{
+            recipients.size(),
+            false,
+            false,
+            tx_collided,
+            tx_end_us,
+        };
+
+        resetCwState(event.src_node_id);
+    }
+
+    metrics_.addChannelBusyTime(tx_duration_us);
+
+    SimEvent tx_end;
+    tx_end.time_us = tx_end_us;
+    tx_end.priority = 0;
+    tx_end.sequence_id = nextSequenceId();
+    tx_end.type = SimEventType::TxEnd;
+    tx_end.tx_id = event.tx_id;
+    tx_end.src_node_id = event.src_node_id;
+    tx_end.dst_id = event.dst_id;
+    event_queue_.push(std::move(tx_end));
+
+    if (recipients.empty()) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            tx_delivery_state_.erase(event.tx_id);
+        }
+
+        if (tx_collided) {
+            metrics_.onTxCollisionFailure();
+        }
+        metrics_.onTxOutcome(false);
+        return;
+    }
+
+    for (const auto& [dst_node_id, distance_m] : recipients) {
+        const double delay_us_fp = (static_cast<double>(distance_m) * 1000000.0) / kSpeedOfLightMps;
+        const uint64_t propagation_delay_us = std::max<uint64_t>(
+            propagation_min_delay_us_,
+            static_cast<uint64_t>(delay_us_fp + 0.5));
+
+        SimEvent delivery = event;
+        delivery.type = SimEventType::RxDelivery;
+        delivery.time_us = tx_end_us + propagation_delay_us;
+        delivery.priority = 3;
+        delivery.sequence_id = nextSequenceId();
+        delivery.tx_id = event.tx_id;
+        delivery.dst_id = dst_node_id;
+        event_queue_.push(std::move(delivery));
+    }
+}
+
+void SimulatedNetwork::executeRetryBackoffEvent(const SimEvent& event)
+{
+    SimEvent retry_start = event;
+    retry_start.type = SimEventType::TxStart;
+    retry_start.sequence_id = nextSequenceId();
+    event_queue_.push(std::move(retry_start));
+}
+
+void SimulatedNetwork::executeTxEndEvent(const SimEvent& event)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    active_transmissions_.erase(event.tx_id);
+    if (event.time_us >= channel_busy_until_us_) {
+        channel_busy_until_us_ = event.time_us;
+    }
+}
+
+void SimulatedNetwork::executeDeliveryEvent(const SimEvent& event)
+{
+    if (compatibility_immediate_delivery_) {
+        const uint8_t* data = event.payload.data();
+        const size_t len = event.payload.size();
+
+        SnapshotEntry src{};
+        std::vector<SnapshotEntry> recipients;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto src_it = nodes_.find(event.src_node_id);
+            if (src_it == nodes_.end()) {
+                metrics_.onTxOutcome(false);
+                return;
+            }
+
+            src = SnapshotEntry{
+                event.src_node_id,
+                src_it->second.link,
+                src_it->second.location->getLocation(),
+                src_it->second.cfg,
+            };
+
+            recipients.reserve(nodes_.size());
+            for (const auto& [node_id, entry] : nodes_) {
+                if (node_id == event.src_node_id) {
+                    continue;
+                }
+                if (event.dst_id != BROADCAST_ADDR && event.dst_id != node_id) {
+                    continue;
+                }
+
+                recipients.push_back(SnapshotEntry{
+                    node_id,
+                    entry.link,
+                    entry.location->getLocation(),
+                    entry.cfg,
+                });
+            }
+        }
+
+        bool delivered_any = false;
+        for (const SnapshotEntry& dst_entry : recipients) {
+            float distance_m = geo::haversine_m(src.location, dst_entry.location);
+            distance_m = std::max(distance_m, kMinDistanceM);
+
+            const float rssi_dbm = computeRssiDbm(src.cfg.tx_power_dbm, distance_m, carrier_freq_mhz_);
+            if (rssi_dbm < dst_entry.cfg.sensitivity_dbm) {
+                metrics_.onRxDropped();
+                continue;
+            }
+
+            const float snr_db = computeSnrDb(rssi_dbm, dst_entry.cfg.noise_floor_dbm);
+            dst_entry.link->deliverFromNetwork(data, len, rssi_dbm, snr_db);
+            metrics_.onRxDelivered(0);
+            delivered_any = true;
+        }
+
+        metrics_.onTxOutcome(delivered_any);
+        return;
+    }
+
+    const uint8_t* data = event.payload.data();
+    const size_t len = event.payload.size();
+
+    SnapshotEntry src{};
+    SnapshotEntry dst{};
+    bool has_endpoints = false;
+    bool collided = false;
+    uint64_t tx_end_us = event.time_us;
+    bool delivered = false;
+    bool per_drop = false;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto state_it = tx_delivery_state_.find(event.tx_id);
+        if (state_it == tx_delivery_state_.end()) {
+            return;
+        }
+        collided = state_it->second.collided;
+        tx_end_us = state_it->second.tx_end_us;
+
+        if (!collided) {
+            auto src_it = nodes_.find(event.src_node_id);
+            auto dst_it = nodes_.find(event.dst_id);
+            if (src_it != nodes_.end() && dst_it != nodes_.end()) {
+                src = SnapshotEntry{
+                    event.src_node_id,
+                    src_it->second.link,
+                    src_it->second.location->getLocation(),
+                    src_it->second.cfg,
+                };
+                dst = SnapshotEntry{
+                    event.dst_id,
+                    dst_it->second.link,
+                    dst_it->second.location->getLocation(),
+                    dst_it->second.cfg,
+                };
+                has_endpoints = true;
+            }
+        }
+    }
+
+    if (!collided && has_endpoints) {
         float distance_m = geo::haversine_m(src.location, dst.location);
         distance_m = std::max(distance_m, kMinDistanceM);
 
         float rssi_dbm = computeRssiDbm(src.cfg.tx_power_dbm, distance_m, carrier_freq_mhz_);
-        if (rssi_dbm < dst.cfg.sensitivity_dbm) {
-            continue;
+        rssi_dbm += sampleFadingDb(event.tx_id, dst.node_id);
+        rssi_dbm += sampleNoiseJitterDb(event.tx_id, dst.node_id);
+
+        if (rssi_dbm >= dst.cfg.sensitivity_dbm) {
+            const float snr_db = computeSnrDb(rssi_dbm, dst.cfg.noise_floor_dbm);
+            if (evaluatePerSuccess(snr_db, event.tx_id, dst.node_id)) {
+                if (!shouldDropForCongestion(event.time_us, event.tx_id, dst.node_id)) {
+                    dst.link->deliverFromNetwork(data, len, rssi_dbm, snr_db);
+                    delivered = true;
+                }
+            } else {
+                per_drop = true;
+            }
+        }
+    }
+
+    if (delivered) {
+        const uint64_t latency_us = (event.time_us > tx_end_us) ? (event.time_us - tx_end_us) : 0;
+        metrics_.onRxDelivered(latency_us);
+    } else {
+        metrics_.onRxDropped();
+    }
+
+    bool finalize_tx = false;
+    bool final_any_delivered = false;
+    bool final_any_per_drop = false;
+    bool final_collided = false;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto state_it = tx_delivery_state_.find(event.tx_id);
+        if (state_it == tx_delivery_state_.end()) {
+            return;
         }
 
-        float snr_db = computeSnrDb(rssi_dbm, dst.cfg.noise_floor_dbm);
-        dst.link->deliverFromNetwork(data, len, rssi_dbm, snr_db);
+        if (delivered) {
+            state_it->second.any_delivered = true;
+        }
+        if (per_drop) {
+            state_it->second.any_per_drop = true;
+        }
+
+        if (state_it->second.pending_deliveries > 0) {
+            --state_it->second.pending_deliveries;
+        }
+
+        if (state_it->second.pending_deliveries == 0) {
+            finalize_tx = true;
+            final_any_delivered = state_it->second.any_delivered;
+            final_any_per_drop = state_it->second.any_per_drop;
+            final_collided = state_it->second.collided;
+            tx_delivery_state_.erase(state_it);
+        }
+    }
+
+    if (finalize_tx) {
+        if (final_collided && !final_any_delivered) {
+            metrics_.onTxCollisionFailure();
+        }
+
+        if (final_any_per_drop && !final_any_delivered) {
+            metrics_.onTxPerFailure();
+        }
+
+        metrics_.onTxOutcome(final_any_delivered);
     }
 }
 
@@ -140,4 +585,159 @@ float SimulatedNetwork::computeRssiDbm(float tx_power_dbm,
 float SimulatedNetwork::computeSnrDb(float rssi_dbm, float noise_floor_dbm)
 {
     return rssi_dbm - noise_floor_dbm;
+}
+
+uint64_t SimulatedNetwork::nextSequenceId()
+{
+    return next_sequence_id_.fetch_add(1);
+}
+
+uint64_t SimulatedNetwork::computeTxDurationUs(size_t payload_len_bytes) const
+{
+    const uint64_t bits = static_cast<uint64_t>(payload_len_bytes) * 8ULL;
+    if (bits == 0) {
+        return 1;
+    }
+
+    const uint64_t rate = static_cast<uint64_t>((data_rate_bps_ == 0) ? 1U : data_rate_bps_);
+    const uint64_t numer = bits * 1000000ULL;
+    const uint64_t duration = (numer + rate - 1ULL) / rate;
+    return std::max<uint64_t>(1ULL, duration);
+}
+
+uint64_t SimulatedNetwork::computeBackoffSlots(uint16_t src_node_id,
+                                               uint8_t retry_count,
+                                               uint64_t tx_id,
+                                               uint16_t cw_current) const
+{
+    if (cw_current == 0) {
+        return 0;
+    }
+
+    uint64_t x = mix64(random_seed_ ^ (static_cast<uint64_t>(src_node_id) << 16U));
+    x ^= mix64(static_cast<uint64_t>(retry_count) << 8U);
+    x ^= mix64(tx_id);
+    x = mix64(x);
+
+    return x % (static_cast<uint64_t>(cw_current) + 1ULL);
+}
+
+double SimulatedNetwork::deterministicUnitInterval(uint64_t key_a,
+                                                   uint64_t key_b,
+                                                   uint64_t key_c) const
+{
+    uint64_t x = mix64(random_seed_ ^ key_a);
+    x ^= mix64(key_b + 0x9E3779B97F4A7C15ULL);
+    x ^= mix64(key_c + 0xBF58476D1CE4E5B9ULL);
+    x = mix64(x);
+
+    return static_cast<double>(x >> 11U) * kInv2Pow53;
+}
+
+float SimulatedNetwork::sampleFadingDb(uint64_t tx_id, uint16_t dst_node_id) const
+{
+    if (fading_stddev_db_ <= 0.0f) {
+        return 0.0f;
+    }
+
+    // Sum of six uniforms approximates a normal variable with stddev ~= 0.707.
+    double sum = 0.0;
+    for (uint64_t i = 0; i < 6; ++i) {
+        sum += deterministicUnitInterval(tx_id, dst_node_id, 0x1000ULL + i);
+    }
+
+    const double z = (sum - 3.0) * 1.4142135623730951; // normalize to stddev ~= 1
+    return static_cast<float>(z * static_cast<double>(fading_stddev_db_));
+}
+
+float SimulatedNetwork::sampleNoiseJitterDb(uint64_t tx_id, uint16_t dst_node_id) const
+{
+    if (noise_jitter_db_ <= 0.0f) {
+        return 0.0f;
+    }
+
+    const double u = deterministicUnitInterval(tx_id, dst_node_id, 0x2000ULL);
+    const double signed_u = 2.0 * u - 1.0;
+    return static_cast<float>(signed_u * static_cast<double>(noise_jitter_db_));
+}
+
+bool SimulatedNetwork::evaluatePerSuccess(float snr_db, uint64_t tx_id, uint16_t dst_node_id) const
+{
+    if (per_model_ == kPerModelDisabled) {
+        return true;
+    }
+
+    if (per_model_ == kPerModelThreshold) {
+        return snr_db >= snr_threshold_db_;
+    }
+
+    if (per_model_ == kPerModelLogistic) {
+        const double x = static_cast<double>(per_logistic_k_) *
+                         static_cast<double>(snr_db - per_logistic_mid_db_);
+        const double clamped = std::max(-60.0, std::min(60.0, x));
+        const double p_success = 1.0 / (1.0 + std::exp(-clamped));
+        const double u = deterministicUnitInterval(tx_id, dst_node_id, 0x3000ULL);
+        return u < p_success;
+    }
+
+    return true;
+}
+
+bool SimulatedNetwork::shouldDropForCongestion(uint64_t event_time_us,
+                                               uint64_t tx_id,
+                                               uint16_t dst_node_id) const
+{
+    if (!enable_congestion_drops_ || congestion_drop_probability_ <= 0.0f) {
+        return false;
+    }
+
+    uint64_t busy_us = 0;
+    uint64_t start_us = 0;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        busy_us = channel_busy_accumulated_us_;
+        start_us = utilization_start_time_us_;
+    }
+
+    if (event_time_us <= start_us) {
+        return false;
+    }
+
+    const uint64_t elapsed_us = event_time_us - start_us;
+    if (elapsed_us < congestion_min_elapsed_us_) {
+        return false;
+    }
+
+    const double utilization_pct =
+        (100.0 * static_cast<double>(busy_us)) / static_cast<double>(elapsed_us);
+    if (utilization_pct < static_cast<double>(congestion_utilization_threshold_pct_)) {
+        return false;
+    }
+
+    const double u = deterministicUnitInterval(tx_id, dst_node_id, 0x4000ULL);
+    return u < static_cast<double>(congestion_drop_probability_);
+}
+
+uint64_t SimulatedNetwork::mix64(uint64_t x)
+{
+    x += 0x9E3779B97F4A7C15ULL;
+    x = (x ^ (x >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    x = (x ^ (x >> 27U)) * 0x94D049BB133111EBULL;
+    return x ^ (x >> 31U);
+}
+
+uint16_t SimulatedNetwork::getOrInitCwState(uint16_t node_id)
+{
+    auto it = cw_state_by_node_.find(node_id);
+    if (it != cw_state_by_node_.end()) {
+        return it->second;
+    }
+
+    cw_state_by_node_[node_id] = cw_min_;
+    return cw_min_;
+}
+
+void SimulatedNetwork::resetCwState(uint16_t node_id)
+{
+    cw_state_by_node_[node_id] = cw_min_;
 }

--- a/simulation/src/simulated_network.cpp
+++ b/simulation/src/simulated_network.cpp
@@ -1,0 +1,143 @@
+#include "simulated_network.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "geo_utils.h"
+#include "network_header.h"
+#include "simulated_link_layer.h"
+#include "simulated_location_provider.h"
+
+/**
+ * @file simulated_network.cpp
+ * @ingroup sim_internal
+ * @brief Internal implementation of channel fan-out, propagation filtering, and delivery.
+ *
+ * Implementation notes:
+ * - Registry access is protected by a mutex.
+ * - Transmission creates a read-only snapshot while holding the lock, then performs
+ *   downstream delivery after lock release to avoid callback-induced lock contention.
+ * - Propagation checks use free-space path loss with a minimum distance clamp.
+ */
+
+namespace {
+
+constexpr float kMinDistanceM = 1.0f;
+
+struct SnapshotEntry {
+    uint16_t node_id;
+    SimulatedLinkLayer* link;
+    GeoPoint location;
+    SimulatedNetwork::RadioConfig cfg;
+};
+
+} // namespace
+
+SimulatedNetwork::SimulatedNetwork(float carrier_freq_mhz)
+    : carrier_freq_mhz_(carrier_freq_mhz)
+{
+}
+
+void SimulatedNetwork::registerNode(uint16_t node_id,
+                                    SimulatedLinkLayer* link,
+                                    const SimulatedLocationProvider* location)
+{
+    const RadioConfig default_cfg{};
+    registerNode(node_id, link, location, default_cfg);
+}
+
+void SimulatedNetwork::registerNode(uint16_t node_id,
+                                    SimulatedLinkLayer* link,
+                                    const SimulatedLocationProvider* location,
+                                    const RadioConfig& cfg)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    nodes_[node_id] = NodeEntry{link, location, cfg};
+}
+
+void SimulatedNetwork::unregisterNode(uint16_t node_id)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    nodes_.erase(node_id);
+}
+
+size_t SimulatedNetwork::nodeCount() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return nodes_.size();
+}
+
+void SimulatedNetwork::transmit(uint16_t src_node_id,
+                                uint16_t dst_id,
+                                const uint8_t* data,
+                                size_t len) const
+{
+    if (!data || len == 0 || len > LORA_MAX_PAYLOAD) {
+        return;
+    }
+
+    SnapshotEntry src{};
+    std::vector<SnapshotEntry> recipients;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto src_it = nodes_.find(src_node_id);
+        if (src_it == nodes_.end()) {
+            return;
+        }
+
+        src = SnapshotEntry{
+            src_node_id,
+            src_it->second.link,
+            src_it->second.location->getLocation(),
+            src_it->second.cfg,
+        };
+
+        recipients.reserve(nodes_.size());
+        for (const auto& [node_id, entry] : nodes_) {
+            if (node_id == src_node_id) {
+                continue;
+            }
+            if (dst_id != BROADCAST_ADDR && dst_id != node_id) {
+                continue;
+            }
+
+            recipients.push_back(SnapshotEntry{
+                node_id,
+                entry.link,
+                entry.location->getLocation(),
+                entry.cfg,
+            });
+        }
+    }
+
+    for (const SnapshotEntry& dst : recipients) {
+        float distance_m = geo::haversine_m(src.location, dst.location);
+        distance_m = std::max(distance_m, kMinDistanceM);
+
+        float rssi_dbm = computeRssiDbm(src.cfg.tx_power_dbm, distance_m, carrier_freq_mhz_);
+        if (rssi_dbm < dst.cfg.sensitivity_dbm) {
+            continue;
+        }
+
+        float snr_db = computeSnrDb(rssi_dbm, dst.cfg.noise_floor_dbm);
+        dst.link->deliverFromNetwork(data, len, rssi_dbm, snr_db);
+    }
+}
+
+float SimulatedNetwork::computeRssiDbm(float tx_power_dbm,
+                                       float distance_m,
+                                       float carrier_freq_mhz)
+{
+    float distance_km = std::max(distance_m / 1000.0f, 0.001f);
+    float fspl_db = 32.44f +
+                    20.0f * std::log10(carrier_freq_mhz) +
+                    20.0f * std::log10(distance_km);
+    return tx_power_dbm - fspl_db;
+}
+
+float SimulatedNetwork::computeSnrDb(float rssi_dbm, float noise_floor_dbm)
+{
+    return rssi_dbm - noise_floor_dbm;
+}

--- a/simulation/src/simulation_builder.cpp
+++ b/simulation/src/simulation_builder.cpp
@@ -26,9 +26,32 @@ struct SimulationScenario::NodeRuntime {
 };
 
 SimulationScenario::SimulationScenario(const SimulationConfig& config)
-    : network_(config.runtime.carrier_freq_mhz)
+    : network_(config.runtime.carrier_freq_mhz,
+               config.runtime.compatibility_immediate_delivery)
 {
+    network_.configureMac(config.runtime.data_rate_bps,
+                          config.runtime.slot_time_us,
+                          config.runtime.difs_us,
+                          config.runtime.max_retries,
+                          config.runtime.propagation_min_delay_us,
+                          config.runtime.cw_min,
+                          config.runtime.cw_max,
+                          config.runtime.random_seed,
+                          config.runtime.enable_collision_model,
+                          static_cast<uint8_t>(config.runtime.per_model),
+                          config.runtime.snr_threshold_db,
+                          config.runtime.per_logistic_k,
+                          config.runtime.per_logistic_mid_db,
+                          config.runtime.fading_stddev_db,
+                          config.runtime.noise_jitter_db,
+                          config.runtime.enable_congestion_drops,
+                          config.runtime.congestion_utilization_threshold_pct,
+                          config.runtime.congestion_drop_probability,
+                          config.runtime.congestion_min_elapsed_us);
+
     clock_.reset(static_cast<uint64_t>(config.runtime.start_time_s) * 1000ULL);
+    network_.setNowUs(clock_.nowMs() * 1000ULL);
+    network_.resetMetrics(clock_.nowMs() * 1000ULL);
 
     for (const SimulationDeviceConfig& device_cfg : config.devices) {
         if (nodes_.find(device_cfg.node_id) != nodes_.end()) {
@@ -102,6 +125,10 @@ void SimulationScenario::stop()
 
 void SimulationScenario::step(uint64_t delta_ms)
 {
+    const uint64_t step_begin_us = clock_.nowMs() * 1000ULL;
+    network_.setNowUs(step_begin_us);
+    network_.processUntil(step_begin_us);
+
     clock_.step(delta_ms);
 
     for (auto& [_, node] : nodes_) {
@@ -111,6 +138,10 @@ void SimulationScenario::step(uint64_t delta_ms)
     for (auto& [_, node] : nodes_) {
         applyDueWaypoints(*node);
     }
+
+    const uint64_t step_end_us = clock_.nowMs() * 1000ULL;
+    network_.setNowUs(step_end_us);
+    network_.processUntil(step_end_us);
 }
 
 size_t SimulationScenario::deviceCount() const
@@ -183,6 +214,16 @@ std::vector<uint16_t> SimulationScenario::nodeIds() const
     }
     std::sort(ids.begin(), ids.end());
     return ids;
+}
+
+SimulationMetricsSnapshot SimulationScenario::metrics() const
+{
+    return network_.metricsSnapshot(clock_.nowMs() * 1000ULL);
+}
+
+void SimulationScenario::resetMetrics()
+{
+    network_.resetMetrics(clock_.nowMs() * 1000ULL);
 }
 
 void SimulationScenario::applyDueWaypoints(NodeRuntime& node)

--- a/simulation/src/simulation_builder.cpp
+++ b/simulation/src/simulation_builder.cpp
@@ -1,0 +1,280 @@
+#include "simulation_builder.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+#include "network_manager.h"
+
+/**
+ * @file simulation_builder.cpp
+ * @ingroup sim_internal
+ * @brief Internal runtime assembly and stepping logic for simulation scenarios.
+ *
+ * This unit wires per-node runtime objects in dependency order:
+ * location provider -> link adapter -> simulated network registration ->
+ * network manager. During each step, the scenario advances global virtual time,
+ * advances node kinematics, then applies due waypoint overrides.
+ */
+
+struct SimulationScenario::NodeRuntime {
+    SimulationDeviceConfig config;
+    std::unique_ptr<SimulatedLocationProvider> location;
+    std::unique_ptr<SimulatedLinkLayer> link;
+    std::unique_ptr<NetworkManager> manager;
+    size_t next_waypoint_idx{0};
+};
+
+SimulationScenario::SimulationScenario(const SimulationConfig& config)
+    : network_(config.runtime.carrier_freq_mhz)
+{
+    clock_.reset(static_cast<uint64_t>(config.runtime.start_time_s) * 1000ULL);
+
+    for (const SimulationDeviceConfig& device_cfg : config.devices) {
+        if (nodes_.find(device_cfg.node_id) != nodes_.end()) {
+            throw std::runtime_error("Duplicate device node_id in simulation config: " +
+                                     std::to_string(static_cast<unsigned long long>(device_cfg.node_id)));
+        }
+
+        auto runtime = std::make_unique<NodeRuntime>();
+        runtime->config = device_cfg;
+
+        SimulatedLocationProvider::Kinematics initial_state{
+            device_cfg.initial_position,
+            device_cfg.speed_cm_s,
+            device_cfg.heading_cdeg,
+            clock_.nowSeconds(),
+        };
+
+        runtime->location = std::make_unique<SimulatedLocationProvider>(initial_state);
+        runtime->link = std::make_unique<SimulatedLinkLayer>(device_cfg.node_id, network_);
+
+        network_.registerNode(device_cfg.node_id,
+                              runtime->link.get(),
+                              runtime->location.get(),
+                              device_cfg.radio);
+
+        runtime->manager = std::make_unique<NetworkManager>(*runtime->link,
+                                                            *runtime->location,
+                                                            config.runtime.network_config);
+
+        std::sort(runtime->config.waypoints.begin(), runtime->config.waypoints.end(),
+                  [](const SimulationWaypointConfig& a, const SimulationWaypointConfig& b) {
+                      return a.at_s < b.at_s;
+                  });
+
+        nodes_.emplace(device_cfg.node_id, std::move(runtime));
+    }
+
+    for (auto& [_, node] : nodes_) {
+        applyDueWaypoints(*node);
+    }
+}
+
+SimulationScenario::~SimulationScenario()
+{
+    stop();
+}
+
+void SimulationScenario::start()
+{
+    if (started_) {
+        return;
+    }
+
+    for (auto& [_, node] : nodes_) {
+        node->manager->start();
+    }
+    started_ = true;
+}
+
+void SimulationScenario::stop()
+{
+    if (!started_) {
+        return;
+    }
+
+    for (auto& [_, node] : nodes_) {
+        node->manager->stop();
+    }
+    started_ = false;
+}
+
+void SimulationScenario::step(uint64_t delta_ms)
+{
+    clock_.step(delta_ms);
+
+    for (auto& [_, node] : nodes_) {
+        node->location->advance(delta_ms);
+    }
+
+    for (auto& [_, node] : nodes_) {
+        applyDueWaypoints(*node);
+    }
+}
+
+size_t SimulationScenario::deviceCount() const
+{
+    return nodes_.size();
+}
+
+SimulationClock& SimulationScenario::clock()
+{
+    return clock_;
+}
+
+const SimulationClock& SimulationScenario::clock() const
+{
+    return clock_;
+}
+
+SimulatedNetwork& SimulationScenario::network()
+{
+    return network_;
+}
+
+const SimulatedNetwork& SimulationScenario::network() const
+{
+    return network_;
+}
+
+NetworkManager* SimulationScenario::manager(uint16_t node_id)
+{
+    auto it = nodes_.find(node_id);
+    if (it == nodes_.end()) {
+        return nullptr;
+    }
+    return it->second->manager.get();
+}
+
+const NetworkManager* SimulationScenario::manager(uint16_t node_id) const
+{
+    auto it = nodes_.find(node_id);
+    if (it == nodes_.end()) {
+        return nullptr;
+    }
+    return it->second->manager.get();
+}
+
+SimulatedLocationProvider* SimulationScenario::locationProvider(uint16_t node_id)
+{
+    auto it = nodes_.find(node_id);
+    if (it == nodes_.end()) {
+        return nullptr;
+    }
+    return it->second->location.get();
+}
+
+const SimulatedLocationProvider* SimulationScenario::locationProvider(uint16_t node_id) const
+{
+    auto it = nodes_.find(node_id);
+    if (it == nodes_.end()) {
+        return nullptr;
+    }
+    return it->second->location.get();
+}
+
+std::vector<uint16_t> SimulationScenario::nodeIds() const
+{
+    std::vector<uint16_t> ids;
+    ids.reserve(nodes_.size());
+    for (const auto& [node_id, _] : nodes_) {
+        ids.push_back(node_id);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+void SimulationScenario::applyDueWaypoints(NodeRuntime& node)
+{
+    const uint32_t now_s = clock_.nowSeconds();
+
+    while (node.next_waypoint_idx < node.config.waypoints.size()) {
+        const SimulationWaypointConfig& waypoint = node.config.waypoints[node.next_waypoint_idx];
+        if (waypoint.at_s > now_s) {
+            break;
+        }
+
+        SimulatedLocationProvider::Kinematics state{
+            waypoint.position,
+            waypoint.speed_cm_s,
+            waypoint.heading_cdeg,
+            now_s,
+        };
+        node.location->setKinematics(state);
+        ++node.next_waypoint_idx;
+    }
+}
+
+SimulationBuilder::SimulationBuilder() = default;
+
+SimulationBuilder& SimulationBuilder::setCarrierFrequencyMhz(float freq_mhz)
+{
+    config_.runtime.carrier_freq_mhz = freq_mhz;
+    return *this;
+}
+
+SimulationBuilder& SimulationBuilder::setStartTimeSeconds(uint32_t start_time_s)
+{
+    config_.runtime.start_time_s = start_time_s;
+    return *this;
+}
+
+SimulationBuilder& SimulationBuilder::setNetworkConfig(const NetworkConfig& cfg)
+{
+    config_.runtime.network_config = cfg;
+    return *this;
+}
+
+SimulationBuilder& SimulationBuilder::addDevice(const SimulationDeviceConfig& cfg)
+{
+    for (SimulationDeviceConfig& existing : config_.devices) {
+        if (existing.node_id == cfg.node_id) {
+            existing = cfg;
+            return *this;
+        }
+    }
+
+    config_.devices.push_back(cfg);
+    return *this;
+}
+
+SimulationBuilder& SimulationBuilder::addWaypoint(uint16_t node_id,
+                                                   const SimulationWaypointConfig& waypoint)
+{
+    for (SimulationDeviceConfig& device : config_.devices) {
+        if (device.node_id == node_id) {
+            device.waypoints.push_back(waypoint);
+            return *this;
+        }
+    }
+
+    throw std::runtime_error("Cannot add waypoint for unknown node_id: " +
+                             std::to_string(static_cast<unsigned long long>(node_id)));
+}
+
+SimulationBuilder& SimulationBuilder::loadConfigFile(const std::string& file_path)
+{
+    config_ = ConfigLoader::loadFromFile(file_path);
+    return *this;
+}
+
+SimulationBuilder& SimulationBuilder::setConfig(const SimulationConfig& cfg)
+{
+    config_ = cfg;
+    return *this;
+}
+
+std::unique_ptr<SimulationScenario> SimulationBuilder::build() const
+{
+    if (config_.devices.empty()) {
+        throw std::runtime_error("Simulation config must contain at least one device");
+    }
+
+    return std::make_unique<SimulationScenario>(config_);
+}
+
+const SimulationConfig& SimulationBuilder::config() const
+{
+    return config_;
+}

--- a/simulation/src/simulation_clock.cpp
+++ b/simulation/src/simulation_clock.cpp
@@ -1,0 +1,27 @@
+#include "simulation_clock.h"
+
+/**
+ * @file simulation_clock.cpp
+ * @ingroup sim_internal
+ * @brief Atomic virtual clock primitive used by scenario stepping.
+ */
+
+void SimulationClock::reset(uint64_t now_ms)
+{
+    now_ms_.store(now_ms);
+}
+
+void SimulationClock::step(uint64_t delta_ms)
+{
+    now_ms_.fetch_add(delta_ms);
+}
+
+uint64_t SimulationClock::nowMs() const
+{
+    return now_ms_.load();
+}
+
+uint32_t SimulationClock::nowSeconds() const
+{
+    return static_cast<uint32_t>(now_ms_.load() / 1000ULL);
+}

--- a/simulation/src/simulation_event_queue.cpp
+++ b/simulation/src/simulation_event_queue.cpp
@@ -1,0 +1,63 @@
+#include "simulation_event_queue.h"
+
+#include <utility>
+
+/**
+ * @file simulation_event_queue.cpp
+ * @ingroup sim_internal
+ * @brief Deterministic event queue implementation for simulation runtime.
+ */
+
+bool SimulationEventQueue::EventCompare::operator()(const SimEvent& lhs, const SimEvent& rhs) const
+{
+    if (lhs.time_us != rhs.time_us) {
+        return lhs.time_us > rhs.time_us;
+    }
+
+    if (lhs.priority != rhs.priority) {
+        return lhs.priority > rhs.priority;
+    }
+
+    return lhs.sequence_id > rhs.sequence_id;
+}
+
+void SimulationEventQueue::push(const SimEvent& event)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    queue_.push(event);
+}
+
+void SimulationEventQueue::push(SimEvent&& event)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    queue_.push(std::move(event));
+}
+
+bool SimulationEventQueue::popDue(uint64_t horizon_us, SimEvent& out_event)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (queue_.empty()) {
+        return false;
+    }
+
+    const SimEvent& next = queue_.top();
+    if (next.time_us > horizon_us) {
+        return false;
+    }
+
+    out_event = next;
+    queue_.pop();
+    return true;
+}
+
+size_t SimulationEventQueue::size() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.size();
+}
+
+void SimulationEventQueue::clear()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    queue_ = std::priority_queue<SimEvent, std::vector<SimEvent>, EventCompare>{};
+}

--- a/simulation/src/simulation_metrics.cpp
+++ b/simulation/src/simulation_metrics.cpp
@@ -1,0 +1,105 @@
+#include "simulation_metrics.h"
+
+/**
+ * @file simulation_metrics.cpp
+ * @ingroup sim_internal
+ * @brief Metrics accumulator implementation for simulation runtime.
+ */
+
+void SimulationMetricsCollector::reset(uint64_t now_us)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    start_time_us_ = now_us;
+    tx_attempts_ = 0;
+    tx_success_ = 0;
+    tx_fail_collision_ = 0;
+    tx_fail_per_ = 0;
+    retransmissions_ = 0;
+    rx_delivered_ = 0;
+    rx_dropped_ = 0;
+    total_latency_us_ = 0;
+    channel_busy_us_ = 0;
+}
+
+void SimulationMetricsCollector::onTxAttempt()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++tx_attempts_;
+}
+
+void SimulationMetricsCollector::onTxOutcome(bool success)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (success) {
+        ++tx_success_;
+    }
+}
+
+void SimulationMetricsCollector::onRetransmission()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++retransmissions_;
+}
+
+void SimulationMetricsCollector::onTxCollisionFailure()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++tx_fail_collision_;
+}
+
+void SimulationMetricsCollector::onTxPerFailure()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++tx_fail_per_;
+}
+
+void SimulationMetricsCollector::onRxDelivered(uint64_t latency_us)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++rx_delivered_;
+    total_latency_us_ += latency_us;
+}
+
+void SimulationMetricsCollector::onRxDropped()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++rx_dropped_;
+}
+
+void SimulationMetricsCollector::addChannelBusyTime(uint64_t busy_us)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    channel_busy_us_ += busy_us;
+}
+
+SimulationMetricsSnapshot SimulationMetricsCollector::snapshot(uint64_t sim_now_us) const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    SimulationMetricsSnapshot snap;
+    snap.tx_attempts = tx_attempts_;
+    snap.tx_success = tx_success_;
+    snap.tx_fail_collision = tx_fail_collision_;
+    snap.tx_fail_per = tx_fail_per_;
+    snap.retransmissions = retransmissions_;
+    snap.rx_delivered = rx_delivered_;
+    snap.rx_dropped = rx_dropped_;
+
+    if (tx_attempts_ > 0) {
+        snap.packet_delivery_ratio =
+            static_cast<double>(tx_success_) / static_cast<double>(tx_attempts_);
+    }
+
+    if (rx_delivered_ > 0) {
+        snap.average_latency_ms =
+            static_cast<double>(total_latency_us_) / static_cast<double>(rx_delivered_) / 1000.0;
+    }
+
+    const uint64_t elapsed_us = (sim_now_us > start_time_us_) ? (sim_now_us - start_time_us_) : 0;
+    if (elapsed_us > 0) {
+        snap.channel_utilization_pct =
+            (100.0 * static_cast<double>(channel_busy_us_)) / static_cast<double>(elapsed_us);
+    }
+
+    return snap;
+}

--- a/simulation/tests/include/simulation_test_base.h
+++ b/simulation/tests/include/simulation_test_base.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "network_manager.h"
+#include "simulation_builder.h"
+
+/**
+ * @file simulation_test_base.h
+ * @ingroup sim_test
+ * @brief Reusable simulation test harness utilities for phase test binaries.
+ */
+
+/**
+ * @ingroup sim_test
+ * @brief Captured application-level delivery event for assertions.
+ */
+struct CapturedMessage {
+    /** Delivered network header. */
+    NetworkHeader header{};
+    /** Delivered application payload bytes. */
+    std::vector<uint8_t> payload;
+};
+
+/**
+ * @ingroup sim_test
+ * @brief Helper wrapper for scenario lifecycle, traffic injection, and capture assertions.
+ */
+class SimulationTestBase {
+public:
+    /**
+     * @brief Construct helper around an existing scenario.
+     * @throws std::runtime_error If @p scenario is null.
+     */
+    explicit SimulationTestBase(std::unique_ptr<SimulationScenario> scenario);
+    ~SimulationTestBase();
+
+    SimulationTestBase(const SimulationTestBase&) = delete;
+    SimulationTestBase& operator=(const SimulationTestBase&) = delete;
+
+    /** @brief Install capture callbacks and start scenario managers. */
+    void start();
+    /** @brief Stop scenario managers. */
+    void stop();
+
+    /**
+     * @brief Send payload from a specific source node using raw pointer input.
+     */
+    int sendFromDevice(uint16_t src_node_id,
+                       const uint8_t* payload,
+                       size_t payload_len,
+                       Priority priority = Priority::NORMAL,
+                       PropagationMode mode = PropagationMode::OMNI,
+                       uint16_t target_heading = 0,
+                       uint8_t max_hops = 3,
+                       uint16_t max_distance_m = 2000,
+                       uint16_t lifetime_s = 30);
+
+    /**
+     * @brief Send payload from a specific source node using vector input.
+     */
+    int sendFromDevice(uint16_t src_node_id,
+                       const std::vector<uint8_t>& payload,
+                       Priority priority = Priority::NORMAL,
+                       PropagationMode mode = PropagationMode::OMNI,
+                       uint16_t target_heading = 0,
+                       uint8_t max_hops = 3,
+                       uint16_t max_distance_m = 2000,
+                       uint16_t lifetime_s = 30);
+
+    /** @brief Clear all captured deliveries across nodes. */
+    void clearCaptured();
+
+    /** @brief Number of captured deliveries for a node. */
+    size_t receivedCount(uint16_t node_id) const;
+    /** @brief Snapshot of captured deliveries for a node. */
+    std::vector<CapturedMessage> receivedMessages(uint16_t node_id) const;
+
+    /**
+     * @brief Step simulation until node has received at least @p min_count messages.
+     */
+    bool waitForMessageCount(uint16_t node_id,
+                             size_t min_count,
+                             uint64_t timeout_ms,
+                             uint64_t step_ms = 50,
+                             uint64_t idle_sleep_ms = 2);
+
+    /**
+     * @brief Repeatedly step simulation until predicate is true or timeout expires.
+     */
+    bool stepUntil(const std::function<bool()>& predicate,
+                   uint64_t timeout_ms,
+                   uint64_t step_ms = 50,
+                   uint64_t idle_sleep_ms = 2);
+
+    /** @brief Check whether node received an exact payload bytes sequence. */
+    bool hasPayload(uint16_t node_id, const std::vector<uint8_t>& payload) const;
+
+    /** @brief Mutable access to wrapped scenario. */
+    SimulationScenario& scenario();
+    /** @brief Const access to wrapped scenario. */
+    const SimulationScenario& scenario() const;
+
+private:
+    void installCaptureCallbacks();
+
+    std::unique_ptr<SimulationScenario> scenario_;
+    mutable std::mutex capture_mutex_;
+    std::unordered_map<uint16_t, std::vector<CapturedMessage>> received_;
+    bool callbacks_installed_{false};
+    bool started_{false};
+};

--- a/simulation/tests/src/simulation_test_base.cpp
+++ b/simulation/tests/src/simulation_test_base.cpp
@@ -1,0 +1,201 @@
+#include "simulation_test_base.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <thread>
+
+/**
+ * @file simulation_test_base.cpp
+ * @ingroup sim_internal
+ * @brief Internal mechanics for capture callback wiring and stepped waiting helpers.
+ */
+
+SimulationTestBase::SimulationTestBase(std::unique_ptr<SimulationScenario> scenario)
+    : scenario_(std::move(scenario))
+{
+    if (!scenario_) {
+        throw std::runtime_error("SimulationTestBase requires a valid scenario");
+    }
+}
+
+SimulationTestBase::~SimulationTestBase()
+{
+    stop();
+}
+
+void SimulationTestBase::start()
+{
+    if (started_) {
+        return;
+    }
+
+    installCaptureCallbacks();
+    scenario_->start();
+    started_ = true;
+}
+
+void SimulationTestBase::stop()
+{
+    if (!started_) {
+        return;
+    }
+
+    scenario_->stop();
+    started_ = false;
+}
+
+int SimulationTestBase::sendFromDevice(uint16_t src_node_id,
+                                       const uint8_t* payload,
+                                       size_t payload_len,
+                                       Priority priority,
+                                       PropagationMode mode,
+                                       uint16_t target_heading,
+                                       uint8_t max_hops,
+                                       uint16_t max_distance_m,
+                                       uint16_t lifetime_s)
+{
+    NetworkManager* mgr = scenario_->manager(src_node_id);
+    if (!mgr) {
+        throw std::runtime_error("Unknown source node_id for sendFromDevice");
+    }
+
+    return mgr->sendMessage(priority,
+                            mode,
+                            target_heading,
+                            max_hops,
+                            max_distance_m,
+                            lifetime_s,
+                            payload,
+                            payload_len);
+}
+
+int SimulationTestBase::sendFromDevice(uint16_t src_node_id,
+                                       const std::vector<uint8_t>& payload,
+                                       Priority priority,
+                                       PropagationMode mode,
+                                       uint16_t target_heading,
+                                       uint8_t max_hops,
+                                       uint16_t max_distance_m,
+                                       uint16_t lifetime_s)
+{
+    return sendFromDevice(src_node_id,
+                          payload.data(),
+                          payload.size(),
+                          priority,
+                          mode,
+                          target_heading,
+                          max_hops,
+                          max_distance_m,
+                          lifetime_s);
+}
+
+void SimulationTestBase::clearCaptured()
+{
+    std::lock_guard<std::mutex> lock(capture_mutex_);
+    received_.clear();
+}
+
+size_t SimulationTestBase::receivedCount(uint16_t node_id) const
+{
+    std::lock_guard<std::mutex> lock(capture_mutex_);
+    const auto it = received_.find(node_id);
+    if (it == received_.end()) {
+        return 0;
+    }
+    return it->second.size();
+}
+
+std::vector<CapturedMessage> SimulationTestBase::receivedMessages(uint16_t node_id) const
+{
+    std::lock_guard<std::mutex> lock(capture_mutex_);
+    const auto it = received_.find(node_id);
+    if (it == received_.end()) {
+        return {};
+    }
+    return it->second;
+}
+
+bool SimulationTestBase::waitForMessageCount(uint16_t node_id,
+                                             size_t min_count,
+                                             uint64_t timeout_ms,
+                                             uint64_t step_ms,
+                                             uint64_t idle_sleep_ms)
+{
+    return stepUntil(
+        [this, node_id, min_count]() { return receivedCount(node_id) >= min_count; },
+        timeout_ms,
+        step_ms,
+        idle_sleep_ms);
+}
+
+bool SimulationTestBase::stepUntil(const std::function<bool()>& predicate,
+                                   uint64_t timeout_ms,
+                                   uint64_t step_ms,
+                                   uint64_t idle_sleep_ms)
+{
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(timeout_ms);
+
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) {
+            return true;
+        }
+
+        scenario_->step(step_ms);
+
+        if (idle_sleep_ms > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(idle_sleep_ms));
+        }
+    }
+
+    return predicate();
+}
+
+bool SimulationTestBase::hasPayload(uint16_t node_id, const std::vector<uint8_t>& payload) const
+{
+    const std::vector<CapturedMessage> messages = receivedMessages(node_id);
+    for (const CapturedMessage& msg : messages) {
+        if (msg.payload == payload) {
+            return true;
+        }
+    }
+    return false;
+}
+
+SimulationScenario& SimulationTestBase::scenario()
+{
+    return *scenario_;
+}
+
+const SimulationScenario& SimulationTestBase::scenario() const
+{
+    return *scenario_;
+}
+
+void SimulationTestBase::installCaptureCallbacks()
+{
+    if (callbacks_installed_) {
+        return;
+    }
+
+    const std::vector<uint16_t> node_ids = scenario_->nodeIds();
+    for (uint16_t node_id : node_ids) {
+        NetworkManager* mgr = scenario_->manager(node_id);
+        if (!mgr) {
+            continue;
+        }
+
+        mgr->setAppRxCallback([this, node_id](const NetworkHeader& hdr,
+                                              const uint8_t* payload,
+                                              size_t payload_len) {
+            CapturedMessage msg;
+            msg.header = hdr;
+            msg.payload.assign(payload, payload + payload_len);
+
+            std::lock_guard<std::mutex> lock(capture_mutex_);
+            received_[node_id].push_back(std::move(msg));
+        });
+    }
+
+    callbacks_installed_ = true;
+}

--- a/simulation/tests/src/test_simulation_phase3.cpp
+++ b/simulation/tests/src/test_simulation_phase3.cpp
@@ -1,0 +1,201 @@
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "simulation_test_base.h"
+
+namespace {
+
+constexpr uint16_t kNodeA = 0x2001;
+constexpr uint16_t kNodeB = 0x2002;
+constexpr uint16_t kNodeC = 0x2003;
+
+constexpr GeoPoint kBasePoint{125000000, 773000000};
+
+void expectTrue(bool condition, const char* message)
+{
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void expectEqSize(size_t actual, size_t expected, const char* message)
+{
+    if (actual != expected) {
+        throw std::runtime_error(std::string(message) +
+                                 " (expected=" +
+                                 std::to_string(static_cast<unsigned long long>(expected)) +
+                                 ", actual=" +
+                                 std::to_string(static_cast<unsigned long long>(actual)) +
+                                 ")");
+    }
+}
+
+void expectEqInt(int actual, int expected, const char* message)
+{
+    if (actual != expected) {
+        throw std::runtime_error(std::string(message) +
+                                 " (expected=" + std::to_string(expected) +
+                                 ", actual=" + std::to_string(actual) + ")");
+    }
+}
+
+SimulationDeviceConfig makeDevice(uint16_t node_id,
+                                  GeoPoint position,
+                                  float tx_power_dbm,
+                                  float sensitivity_dbm)
+{
+    SimulationDeviceConfig cfg;
+    cfg.node_id = node_id;
+    cfg.initial_position = position;
+    cfg.speed_cm_s = 0;
+    cfg.heading_cdeg = 0;
+    cfg.radio.tx_power_dbm = tx_power_dbm;
+    cfg.radio.noise_floor_dbm = -110.0f;
+    cfg.radio.sensitivity_dbm = sensitivity_dbm;
+    return cfg;
+}
+
+SimulationConfig makeBaseConfig()
+{
+    SimulationConfig cfg;
+    cfg.runtime.carrier_freq_mhz = 868.0f;
+    cfg.runtime.start_time_s = 1000;
+    cfg.runtime.network_config = NetworkConfig{64, 8, 16};
+    return cfg;
+}
+
+void testBroadcastDelivery()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{124996000, 773002000}, 14.0f, -118.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {10, 20, 30, 40};
+    const int rc = test.sendFromDevice(kNodeA, payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "broadcast send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1200), "node B did not receive broadcast");
+    expectTrue(test.waitForMessageCount(kNodeC, 1, 1200), "node C did not receive broadcast");
+
+    expectTrue(test.hasPayload(kNodeB, payload), "node B payload mismatch");
+    expectTrue(test.hasPayload(kNodeC, payload), "node C payload mismatch");
+
+    expectEqSize(test.receivedCount(kNodeA), 0, "origin node should not deliver its own message");
+
+    test.stop();
+}
+
+void testDistanceBasedReachability()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -95.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -95.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{130000000, 773000000}, 14.0f, -95.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {1, 2, 3};
+    const int rc = test.sendFromDevice(kNodeA, payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "distance test send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1200), "nearby node B should receive message");
+
+    test.stepUntil([]() { return false; }, 400);
+    expectEqSize(test.receivedCount(kNodeC), 0, "far node C should remain unreachable");
+
+    test.stop();
+}
+
+void testWaypointMovementChangesConnectivity()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -95.0f));
+
+    SimulationDeviceConfig moving = makeDevice(kNodeB, GeoPoint{130000000, 773000000}, 14.0f, -95.0f);
+    moving.waypoints.push_back(SimulationWaypointConfig{
+        1002,
+        GeoPoint{125006000, 773004000},
+        0,
+        0,
+    });
+
+    cfg.devices.push_back(moving);
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> before_move_payload = {9, 9, 9};
+    int rc = test.sendFromDevice(kNodeA, before_move_payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "pre-move send should succeed");
+
+    test.stepUntil([]() { return false; }, 300);
+    expectEqSize(test.receivedCount(kNodeB), 0,
+                 "moving node should not receive before entering range");
+
+    test.scenario().step(2500);
+    test.clearCaptured();
+
+    const std::vector<uint8_t> after_move_payload = {7, 7, 7};
+    rc = test.sendFromDevice(kNodeA, after_move_payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "post-move send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1200),
+               "moving node should receive after entering range");
+    expectTrue(test.hasPayload(kNodeB, after_move_payload),
+               "moving node received wrong payload after moving");
+
+    test.stop();
+}
+
+int runTest(const char* name, const std::function<void()>& fn)
+{
+    try {
+        fn();
+        std::printf("[PASS] %s\n", name);
+        return 0;
+    } catch (const std::exception& ex) {
+        std::printf("[FAIL] %s: %s\n", name, ex.what());
+        return 1;
+    } catch (...) {
+        std::printf("[FAIL] %s: unknown exception\n", name);
+        return 1;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    int failures = 0;
+
+    failures += runTest("broadcast_delivery", testBroadcastDelivery);
+    failures += runTest("distance_based_reachability", testDistanceBasedReachability);
+    failures += runTest("waypoint_movement_changes_connectivity", testWaypointMovementChangesConnectivity);
+
+    if (failures == 0) {
+        std::printf("All phase 3 simulation tests passed\n");
+        return 0;
+    }
+
+    std::printf("Phase 3 simulation tests failed (%d)\n", failures);
+    return 1;
+}

--- a/simulation/tests/src/test_simulation_phase3.cpp
+++ b/simulation/tests/src/test_simulation_phase3.cpp
@@ -44,6 +44,30 @@ void expectEqInt(int actual, int expected, const char* message)
     }
 }
 
+void expectGteSize(size_t actual, size_t minimum, const char* message)
+{
+    if (actual < minimum) {
+        throw std::runtime_error(std::string(message) +
+                                 " (minimum=" +
+                                 std::to_string(static_cast<unsigned long long>(minimum)) +
+                                 ", actual=" +
+                                 std::to_string(static_cast<unsigned long long>(actual)) +
+                                 ")");
+    }
+}
+
+void expectGteU64(uint64_t actual, uint64_t minimum, const char* message)
+{
+    if (actual < minimum) {
+        throw std::runtime_error(std::string(message) +
+                                 " (minimum=" +
+                                 std::to_string(static_cast<unsigned long long>(minimum)) +
+                                 ", actual=" +
+                                 std::to_string(static_cast<unsigned long long>(actual)) +
+                                 ")");
+    }
+}
+
 SimulationDeviceConfig makeDevice(uint16_t node_id,
                                   GeoPoint position,
                                   float tx_power_dbm,
@@ -66,6 +90,54 @@ SimulationConfig makeBaseConfig()
     cfg.runtime.carrier_freq_mhz = 868.0f;
     cfg.runtime.start_time_s = 1000;
     cfg.runtime.network_config = NetworkConfig{64, 8, 16};
+    return cfg;
+}
+
+SimulationConfig makeTimedMacConfig()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.runtime.compatibility_immediate_delivery = false;
+    cfg.runtime.data_rate_bps = 20000;
+    cfg.runtime.slot_time_us = 5000;
+    cfg.runtime.difs_us = 5000;
+    cfg.runtime.max_retries = 6;
+    return cfg;
+}
+
+SimulationConfig makeCollisionConfig()
+{
+    SimulationConfig cfg = makeTimedMacConfig();
+    cfg.runtime.enable_collision_model = true;
+    cfg.runtime.random_seed = 42;
+    cfg.runtime.cw_min = 3;
+    cfg.runtime.cw_max = 31;
+    cfg.runtime.slot_time_us = 1000;
+    cfg.runtime.difs_us = 0;
+    return cfg;
+}
+
+SimulationConfig makePhase4EffectsConfig()
+{
+    SimulationConfig cfg = makeTimedMacConfig();
+    cfg.runtime.enable_collision_model = false;
+    cfg.runtime.random_seed = 123;
+    cfg.runtime.cw_min = 1;
+    cfg.runtime.cw_max = 15;
+    cfg.runtime.data_rate_bps = 500000;
+    cfg.runtime.slot_time_us = 1000;
+    cfg.runtime.difs_us = 0;
+    cfg.runtime.propagation_min_delay_us = 0;
+    return cfg;
+}
+
+SimulationConfig makeCongestionConfig()
+{
+    SimulationConfig cfg = makePhase4EffectsConfig();
+    cfg.runtime.enable_congestion_drops = true;
+    cfg.runtime.congestion_utilization_threshold_pct = 0.0f;
+    cfg.runtime.congestion_drop_probability = 1.0f;
+    cfg.runtime.congestion_min_elapsed_us = 0;
+    cfg.runtime.per_model = SimulationRuntimeConfig::PerModel::Disabled;
     return cfg;
 }
 
@@ -166,6 +238,275 @@ void testWaypointMovementChangesConnectivity()
     test.stop();
 }
 
+void testTimedDeliveryRequiresProgressedVirtualTime()
+{
+    SimulationConfig cfg = makeTimedMacConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -118.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    std::vector<uint8_t> payload(40, 0x5A); // ~34 ms including network header at 20 kbps
+    const int rc = test.sendFromDevice(kNodeA, payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "timed send should succeed");
+
+    expectEqSize(test.receivedCount(kNodeB), 0,
+                 "receiver should not deliver before simulation time progresses");
+
+    test.scenario().step(20);
+    expectEqSize(test.receivedCount(kNodeB), 0,
+                 "receiver should not deliver before tx duration elapses");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1200, 10, 1),
+               "receiver should deliver once tx duration is elapsed");
+    expectTrue(test.hasPayload(kNodeB, payload),
+               "timed-delivery payload mismatch");
+
+    test.stop();
+}
+
+void testBusyChannelDefersSecondTransmission()
+{
+    SimulationConfig cfg = makeTimedMacConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -118.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    std::vector<uint8_t> payload_one(40, 0x11); // ~34 ms including network header at 20 kbps
+    std::vector<uint8_t> payload_two(40, 0x22); // queued while channel is busy
+
+    int rc = test.sendFromDevice(kNodeA, payload_one);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "first timed send should succeed");
+
+    rc = test.sendFromDevice(kNodeA, payload_two);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "second timed send should succeed");
+
+    test.scenario().step(45);
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 300, 0, 1),
+               "first transmission should be delivered before deferred second transmission");
+    expectEqSize(test.receivedCount(kNodeB), 1,
+                 "second transmission should be deferred while channel is busy");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 2, 1200, 10, 1),
+               "deferred transmission should eventually deliver");
+
+    expectTrue(test.hasPayload(kNodeB, payload_one),
+               "receiver missing first deferred test payload");
+    expectTrue(test.hasPayload(kNodeB, payload_two),
+               "receiver missing second deferred test payload");
+
+    const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+    expectGteU64(metrics.retransmissions, 1,
+                 "busy-channel test should record at least one retransmission");
+
+    test.stop();
+}
+
+void testCollisionModelDropsSimultaneousTransmissions()
+{
+    SimulationConfig cfg = makeCollisionConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{125003000, 773003000}, 14.0f, -118.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload_a = {0xA1, 0xA2, 0xA3, 0xA4};
+    const std::vector<uint8_t> payload_b = {0xB1, 0xB2, 0xB3, 0xB4};
+
+    int rc = test.sendFromDevice(kNodeA, payload_a);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                "collision source A send should succeed");
+
+    rc = test.sendFromDevice(kNodeB, payload_b);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                "collision source B send should succeed");
+
+    test.stepUntil([]() { return false; }, 600, 10, 1);
+
+    expectEqSize(test.receivedCount(kNodeC), 0,
+                 "receiver should drop overlapping simultaneous transmissions");
+
+    const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+    expectGteU64(metrics.tx_fail_collision, 2,
+                 "collision model should count collision failures for both transmitters");
+    expectGteSize(static_cast<size_t>(metrics.rx_dropped), 2,
+                  "collision model should account dropped receptions");
+
+    test.stop();
+}
+
+void testPropagationDelayDeliversNearBeforeFar()
+{
+    SimulationConfig cfg = makePhase4EffectsConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, GeoPoint{0, 0}, 30.0f, -200.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{0, 10000}, 14.0f, -200.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{0, 1790000000}, 14.0f, -200.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {0x31, 0x32, 0x33};
+    const int rc = test.sendFromDevice(kNodeA,
+                                       payload,
+                                       Priority::NORMAL,
+                                       PropagationMode::OMNI,
+                                       0,
+                                       0,
+                                       65535,
+                                       30);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                "propagation-delay send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 600, 5, 1),
+               "near node should receive first under propagation-delay model");
+    expectEqSize(test.receivedCount(kNodeC), 0,
+                 "far node should still be pending while near node already delivered");
+
+    expectTrue(test.waitForMessageCount(kNodeC, 1, 1200, 10, 1),
+               "far node should receive after longer propagation delay");
+
+    test.stop();
+}
+
+void testPerThresholdModelDropAndAllow()
+{
+    SimulationConfig cfg = makePhase4EffectsConfig();
+    cfg.runtime.per_model = SimulationRuntimeConfig::PerModel::Threshold;
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -200.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -200.0f));
+
+    SimulationBuilder builder;
+
+    cfg.runtime.snr_threshold_db = 80.0f;
+    builder.setConfig(cfg);
+
+    {
+        SimulationTestBase test(builder.build());
+        test.start();
+
+        const std::vector<uint8_t> payload = {0x41, 0x42, 0x43};
+        const int rc = test.sendFromDevice(kNodeA,
+                                           payload,
+                                           Priority::NORMAL,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           10000,
+                                           30);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "PER-threshold drop send should succeed");
+
+        test.stepUntil([]() { return false; }, 500, 10, 1);
+        expectEqSize(test.receivedCount(kNodeB), 0,
+                     "high SNR threshold should drop frame in PER threshold mode");
+
+        const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+        expectGteU64(metrics.tx_fail_per, 1,
+                     "PER threshold drop should increment tx_fail_per metric");
+
+        test.stop();
+    }
+
+    cfg.runtime.snr_threshold_db = -20.0f;
+    builder.setConfig(cfg);
+
+    {
+        SimulationTestBase test(builder.build());
+        test.start();
+
+        const std::vector<uint8_t> payload = {0x51, 0x52, 0x53};
+        const int rc = test.sendFromDevice(kNodeA,
+                                           payload,
+                                           Priority::NORMAL,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           10000,
+                                           30);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "PER-threshold allow send should succeed");
+
+        expectTrue(test.waitForMessageCount(kNodeB, 1, 700, 10, 1),
+                   "lower SNR threshold should allow PER-threshold delivery");
+
+        test.stop();
+    }
+}
+
+void testChannelUtilizationMetricsIncreaseAfterTraffic()
+{
+    SimulationConfig cfg = makePhase4EffectsConfig();
+    cfg.runtime.enable_congestion_drops = false;
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -118.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload(80, 0x66);
+    const int rc = test.sendFromDevice(kNodeA, payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                "utilization test send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 800, 5, 1),
+               "utilization test receiver should get payload");
+
+    const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+    expectTrue(metrics.channel_utilization_pct > 0.0,
+               "channel utilization should increase after timed transmission");
+
+    test.stop();
+}
+
+void testCongestionDropModeCanForceDrops()
+{
+    SimulationConfig cfg = makeCongestionConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -118.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125005000, 773005000}, 14.0f, -118.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload(32, 0x77);
+    const int rc = test.sendFromDevice(kNodeA, payload);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                "congestion-drop test send should succeed");
+
+    test.stepUntil([]() { return false; }, 600, 10, 1);
+    expectEqSize(test.receivedCount(kNodeB), 0,
+                 "forced congestion-drop configuration should suppress delivery");
+
+    const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+    expectGteU64(metrics.rx_dropped, 1,
+                 "congestion-drop test should increment dropped reception count");
+
+    test.stop();
+}
+
 int runTest(const char* name, const std::function<void()>& fn)
 {
     try {
@@ -190,6 +531,20 @@ int main()
     failures += runTest("broadcast_delivery", testBroadcastDelivery);
     failures += runTest("distance_based_reachability", testDistanceBasedReachability);
     failures += runTest("waypoint_movement_changes_connectivity", testWaypointMovementChangesConnectivity);
+    failures += runTest("timed_delivery_requires_progressed_virtual_time",
+                        testTimedDeliveryRequiresProgressedVirtualTime);
+    failures += runTest("busy_channel_defers_second_transmission",
+                        testBusyChannelDefersSecondTransmission);
+    failures += runTest("collision_model_drops_simultaneous_transmissions",
+                        testCollisionModelDropsSimultaneousTransmissions);
+    failures += runTest("propagation_delay_delivers_near_before_far",
+                        testPropagationDelayDeliversNearBeforeFar);
+    failures += runTest("per_threshold_model_drop_and_allow",
+                        testPerThresholdModelDropAndAllow);
+    failures += runTest("channel_utilization_metrics_increase_after_traffic",
+                        testChannelUtilizationMetricsIncreaseAfterTraffic);
+    failures += runTest("congestion_drop_mode_can_force_drops",
+                        testCongestionDropModeCanForceDrops);
 
     if (failures == 0) {
         std::printf("All phase 3 simulation tests passed\n");

--- a/simulation/tests/src/test_simulation_phase4.cpp
+++ b/simulation/tests/src/test_simulation_phase4.cpp
@@ -1,0 +1,270 @@
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "simulation_test_base.h"
+
+namespace {
+
+constexpr uint16_t kNodeA = 0x3001;
+constexpr uint16_t kNodeB = 0x3002;
+constexpr uint16_t kNodeC = 0x3003;
+constexpr uint16_t kNodeD = 0x3004;
+
+constexpr GeoPoint kBasePoint{125000000, 773000000};
+
+void expectTrue(bool condition, const char* message)
+{
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void expectEqSize(size_t actual, size_t expected, const char* message)
+{
+    if (actual != expected) {
+        throw std::runtime_error(std::string(message) +
+                                 " (expected=" +
+                                 std::to_string(static_cast<unsigned long long>(expected)) +
+                                 ", actual=" +
+                                 std::to_string(static_cast<unsigned long long>(actual)) +
+                                 ")");
+    }
+}
+
+void expectEqInt(int actual, int expected, const char* message)
+{
+    if (actual != expected) {
+        throw std::runtime_error(std::string(message) +
+                                 " (expected=" + std::to_string(expected) +
+                                 ", actual=" + std::to_string(actual) + ")");
+    }
+}
+
+SimulationDeviceConfig makeDevice(uint16_t node_id,
+                                  GeoPoint position,
+                                  float tx_power_dbm,
+                                  float sensitivity_dbm)
+{
+    SimulationDeviceConfig cfg;
+    cfg.node_id = node_id;
+    cfg.initial_position = position;
+    cfg.speed_cm_s = 0;
+    cfg.heading_cdeg = 0;
+    cfg.radio.tx_power_dbm = tx_power_dbm;
+    cfg.radio.noise_floor_dbm = -110.0f;
+    cfg.radio.sensitivity_dbm = sensitivity_dbm;
+    return cfg;
+}
+
+SimulationConfig makeBaseConfig()
+{
+    SimulationConfig cfg;
+    cfg.runtime.carrier_freq_mhz = 868.0f;
+    cfg.runtime.start_time_s = 1000;
+    cfg.runtime.network_config = NetworkConfig{64, 8, 16};
+    return cfg;
+}
+
+void testTtlExpiryDropsDelayedForward()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125000000, 773100000}, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{125000000, 773200000}, 14.0f, -82.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {0xAA, 0xBB, 0xCC};
+    const int rc = test.sendFromDevice(kNodeA,
+                                       payload,
+                                       Priority::LOW,
+                                       PropagationMode::OMNI,
+                                       0,
+                                       3,
+                                       4000,
+                                       1);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "TTL test send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1200),
+               "relay node should receive original frame");
+
+    // Advance virtual time so forwarded copies are expired when they arrive.
+    test.scenario().step(3000);
+
+    test.stepUntil([]() { return false; }, 1300);
+
+    expectEqSize(test.receivedCount(kNodeC), 0,
+                 "destination should not receive expired forwarded frame");
+
+    test.stop();
+}
+
+void testDirectionalConeForwardingPath()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125000000, 773100000}, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{125100000, 773000000}, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeD, GeoPoint{125000000, 773200000}, 14.0f, -82.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {0x11, 0x22, 0x33, 0x44};
+    const int rc = test.sendFromDevice(kNodeA,
+                                       payload,
+                                       Priority::NORMAL,
+                                       PropagationMode::DIRECTIONAL,
+                                       9000,
+                                       3,
+                                       5000,
+                                       30);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "directional send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1500),
+               "in-cone relay node should receive directional frame");
+    expectTrue(test.waitForMessageCount(kNodeC, 1, 1500),
+               "out-of-cone node should still deliver locally");
+    expectTrue(test.waitForMessageCount(kNodeD, 1, 1800),
+               "far east node should be reached via relay");
+
+    const auto d_msgs = test.receivedMessages(kNodeD);
+    expectEqSize(d_msgs.size(), 1, "destination should get exactly one directional message");
+
+    const SimulatedLocationProvider* relay_loc = test.scenario().locationProvider(kNodeB);
+    expectTrue(relay_loc != nullptr, "relay location provider missing");
+
+    const GeoPoint relay_point = relay_loc->getLocation();
+    const GeoPoint tx_point = d_msgs.front().header.txPoint();
+    expectTrue(tx_point.lat == relay_point.lat && tx_point.lon == relay_point.lon,
+               "directional destination should see relay tx location in header");
+
+    test.stop();
+}
+
+void testMultiHopRelayToUnreachableNode()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125000000, 773100000}, 14.0f, -82.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{125000000, 773200000}, 14.0f, -82.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {5, 4, 3, 2, 1};
+    const int rc = test.sendFromDevice(kNodeA,
+                                       payload,
+                                       Priority::NORMAL,
+                                       PropagationMode::OMNI,
+                                       0,
+                                       2,
+                                       5000,
+                                       30);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "multihop send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeB, 1, 1200), "relay should receive initial frame");
+    expectTrue(test.waitForMessageCount(kNodeC, 1, 2000), "destination should receive relayed frame");
+
+    const auto c_msgs = test.receivedMessages(kNodeC);
+    expectEqSize(c_msgs.size(), 1, "destination should receive one relayed message");
+
+    const NetworkHeader& hdr = c_msgs.front().header;
+    expectTrue(hdr.hops_remaining == 1,
+               "destination should observe decremented hop count from relay");
+
+    const SimulatedLocationProvider* relay_loc = test.scenario().locationProvider(kNodeB);
+    expectTrue(relay_loc != nullptr, "relay location provider missing");
+
+    const GeoPoint relay_point = relay_loc->getLocation();
+    const GeoPoint tx_point = hdr.txPoint();
+    expectTrue(tx_point.lat == relay_point.lat && tx_point.lon == relay_point.lon,
+               "destination should observe relay location as tx point");
+
+    test.stop();
+}
+
+void testDuplicateSuppressionAtReceiver()
+{
+    SimulationConfig cfg = makeBaseConfig();
+    cfg.devices.push_back(makeDevice(kNodeA, kBasePoint, 14.0f, -95.0f));
+    cfg.devices.push_back(makeDevice(kNodeB, GeoPoint{125000000, 773050000}, 14.0f, -95.0f));
+    cfg.devices.push_back(makeDevice(kNodeC, GeoPoint{125000000, 773100000}, 14.0f, -95.0f));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {0xDE, 0xAD, 0xBE, 0xEF};
+    const int rc = test.sendFromDevice(kNodeA,
+                                       payload,
+                                       Priority::NORMAL,
+                                       PropagationMode::OMNI,
+                                       0,
+                                       3,
+                                       5000,
+                                       30);
+    expectEqInt(rc, static_cast<int>(NetworkError::Ok), "duplicate suppression send should succeed");
+
+    expectTrue(test.waitForMessageCount(kNodeC, 1, 1000),
+               "receiver should get initial direct copy");
+
+    // Let relay duplicates propagate; receiver should still deliver only once.
+    test.stepUntil([]() { return false; }, 1600);
+
+    expectEqSize(test.receivedCount(kNodeC), 1,
+                 "receiver should deliver one message despite duplicate relays");
+
+    test.stop();
+}
+
+int runTest(const char* name, const std::function<void()>& fn)
+{
+    try {
+        fn();
+        std::printf("[PASS] %s\n", name);
+        return 0;
+    } catch (const std::exception& ex) {
+        std::printf("[FAIL] %s: %s\n", name, ex.what());
+        return 1;
+    } catch (...) {
+        std::printf("[FAIL] %s: unknown exception\n", name);
+        return 1;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    int failures = 0;
+
+    failures += runTest("ttl_expiry_drops_delayed_forward", testTtlExpiryDropsDelayedForward);
+    failures += runTest("directional_cone_forwarding_path", testDirectionalConeForwardingPath);
+    failures += runTest("multi_hop_relay_to_unreachable_node", testMultiHopRelayToUnreachableNode);
+    failures += runTest("duplicate_suppression_at_receiver", testDuplicateSuppressionAtReceiver);
+
+    if (failures == 0) {
+        std::printf("All phase 4 simulation tests passed\n");
+        return 0;
+    }
+
+    std::printf("Phase 4 simulation tests failed (%d)\n", failures);
+    return 1;
+}

--- a/simulation/tests/src/test_simulation_phase5.cpp
+++ b/simulation/tests/src/test_simulation_phase5.cpp
@@ -1,0 +1,348 @@
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "simulation_test_base.h"
+
+namespace {
+
+constexpr uint16_t kNodeBase = 0x5000;
+constexpr GeoPoint kBasePoint{125000000, 773000000};
+
+void expectTrue(bool condition, const char* message)
+{
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void expectEqInt(int actual, int expected, const char* message)
+{
+    if (actual != expected) {
+        throw std::runtime_error(std::string(message) +
+                                 " (expected=" + std::to_string(expected) +
+                                 ", actual=" + std::to_string(actual) + ")");
+    }
+}
+
+void expectEqSize(size_t actual, size_t expected, const char* message)
+{
+    if (actual != expected) {
+        throw std::runtime_error(std::string(message) +
+                                 " (expected=" +
+                                 std::to_string(static_cast<unsigned long long>(expected)) +
+                                 ", actual=" +
+                                 std::to_string(static_cast<unsigned long long>(actual)) +
+                                 ")");
+    }
+}
+
+SimulationDeviceConfig makeDevice(uint16_t node_id,
+                                  GeoPoint position,
+                                  float tx_power_dbm,
+                                  float sensitivity_dbm,
+                                  uint16_t speed_cm_s = 0,
+                                  uint16_t heading_cdeg = 0)
+{
+    SimulationDeviceConfig cfg;
+    cfg.node_id = node_id;
+    cfg.initial_position = position;
+    cfg.speed_cm_s = speed_cm_s;
+    cfg.heading_cdeg = heading_cdeg;
+    cfg.radio.tx_power_dbm = tx_power_dbm;
+    cfg.radio.noise_floor_dbm = -110.0f;
+    cfg.radio.sensitivity_dbm = sensitivity_dbm;
+    return cfg;
+}
+
+SimulationConfig makeStressConfig(size_t node_count,
+                                  uint16_t spacing_e7 = 8000,
+                                  uint16_t speed_cm_s = 0)
+{
+    SimulationConfig cfg;
+    cfg.runtime.carrier_freq_mhz = 868.0f;
+    cfg.runtime.start_time_s = 2000;
+    cfg.runtime.network_config = NetworkConfig{256, 8, 256};
+
+    // Source node at the center of the grid.
+    cfg.devices.push_back(makeDevice(kNodeBase, kBasePoint, 14.0f, -118.0f, speed_cm_s, 0));
+
+    size_t added = 1;
+    size_t ring = 1;
+    while (added < node_count) {
+        for (int dy = -static_cast<int>(ring); dy <= static_cast<int>(ring) && added < node_count; ++dy) {
+            for (int dx = -static_cast<int>(ring); dx <= static_cast<int>(ring) && added < node_count; ++dx) {
+                if (std::abs(dx) != static_cast<int>(ring) &&
+                    std::abs(dy) != static_cast<int>(ring)) {
+                    continue;
+                }
+
+                if (dx == 0 && dy == 0) {
+                    continue;
+                }
+
+                GeoPoint pos{
+                    kBasePoint.lat + dy * static_cast<int32_t>(spacing_e7),
+                    kBasePoint.lon + dx * static_cast<int32_t>(spacing_e7),
+                };
+
+                const uint16_t node_id = static_cast<uint16_t>(kNodeBase + added);
+                const uint16_t heading_cdeg = static_cast<uint16_t>(((added * 137U) % 360U) * 100U);
+                cfg.devices.push_back(makeDevice(node_id,
+                                                 pos,
+                                                 14.0f,
+                                                 -118.0f,
+                                                 speed_cm_s,
+                                                 heading_cdeg));
+                ++added;
+            }
+        }
+        ++ring;
+    }
+
+    return cfg;
+}
+
+using Snapshot = std::unordered_map<uint16_t, std::array<uint64_t, 2>>;
+
+Snapshot captureSnapshot(const SimulationTestBase& test)
+{
+    Snapshot out;
+    const std::vector<uint16_t> node_ids = test.scenario().nodeIds();
+
+    for (uint16_t node_id : node_ids) {
+        const std::vector<CapturedMessage> msgs = test.receivedMessages(node_id);
+
+        uint64_t hash = 1469598103934665603ULL; // FNV-1a offset basis
+        for (const CapturedMessage& msg : msgs) {
+            hash ^= static_cast<uint64_t>(msg.header.message_id);
+            hash *= 1099511628211ULL;
+
+            hash ^= static_cast<uint64_t>(msg.header.timestamp);
+            hash *= 1099511628211ULL;
+
+            for (uint8_t b : msg.payload) {
+                hash ^= static_cast<uint64_t>(b);
+                hash *= 1099511628211ULL;
+            }
+        }
+
+        out[node_id] = {
+            static_cast<uint64_t>(msgs.size()),
+            hash,
+        };
+    }
+
+    return out;
+}
+
+Snapshot runRepeatableWorkload()
+{
+    SimulationBuilder builder;
+    builder.setConfig(makeStressConfig(20, 10000, 120));
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> msg_a = {1, 2, 3, 4, 5};
+    const std::vector<uint8_t> msg_b = {9, 8, 7};
+
+    for (size_t i = 0; i < 6; ++i) {
+        const int rc = test.sendFromDevice(kNodeBase,
+                                           msg_a,
+                                           Priority::NORMAL,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           3000,
+                                           30);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "repeatability source send should succeed");
+        test.scenario().step(120);
+    }
+
+    const uint16_t second_sender = static_cast<uint16_t>(kNodeBase + 1);
+    for (size_t i = 0; i < 4; ++i) {
+        const int rc = test.sendFromDevice(second_sender,
+                                           msg_b,
+                                           Priority::HIGH,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           3000,
+                                           30);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "repeatability secondary send should succeed");
+        test.scenario().step(120);
+    }
+
+    const std::vector<uint16_t> node_ids = test.scenario().nodeIds();
+    for (uint16_t node_id : node_ids) {
+        if (node_id == kNodeBase) {
+            expectTrue(test.waitForMessageCount(node_id, 4, 3000),
+                       "source node should receive four messages from secondary sender");
+            continue;
+        }
+
+        if (node_id == second_sender) {
+            expectTrue(test.waitForMessageCount(node_id, 6, 3000),
+                       "secondary sender should receive six messages from source sender");
+            continue;
+        }
+
+        expectTrue(test.waitForMessageCount(node_id, 10, 3000),
+                   "receiver node should receive all workload messages");
+    }
+
+    Snapshot snapshot = captureSnapshot(test);
+    test.stop();
+    return snapshot;
+}
+
+void testLargeScaleBroadcastBurstNoLoss()
+{
+    SimulationBuilder builder;
+    builder.setConfig(makeStressConfig(80, 8000, 0));
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const std::vector<uint8_t> payload = {0x10, 0x20, 0x30, 0x40, 0x50};
+    constexpr size_t kBurstCount = 25;
+
+    for (size_t i = 0; i < kBurstCount; ++i) {
+        const int rc = test.sendFromDevice(kNodeBase,
+                                           payload,
+                                           Priority::NORMAL,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           3000,
+                                           60);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "stress burst send should succeed");
+    }
+
+    const std::vector<uint16_t> node_ids = test.scenario().nodeIds();
+    for (uint16_t node_id : node_ids) {
+        if (node_id == kNodeBase) {
+            expectEqSize(test.receivedCount(node_id), 0,
+                         "source should not receive its own broadcasts");
+            continue;
+        }
+
+        expectTrue(test.waitForMessageCount(node_id, kBurstCount, 5000),
+                   "receiver missed broadcast messages during stress burst");
+        expectEqSize(test.receivedCount(node_id), kBurstCount,
+                     "receiver message count mismatch after stress burst");
+    }
+
+    test.stop();
+}
+
+void testRepeatabilitySnapshotStableAcrossRuns()
+{
+    const Snapshot first = runRepeatableWorkload();
+    const Snapshot second = runRepeatableWorkload();
+
+    expectEqSize(first.size(), second.size(),
+                 "repeatability runs should produce same node set size");
+
+    for (const auto& [node_id, summary] : first) {
+        const auto it = second.find(node_id);
+        expectTrue(it != second.end(), "missing node summary in second run");
+
+        const auto& second_summary = it->second;
+        expectTrue(summary[0] == second_summary[0],
+                   "message count mismatch between repeatability runs");
+        expectTrue(summary[1] == second_summary[1],
+                   "message content/hash mismatch between repeatability runs");
+    }
+}
+
+void testHundredNodeStepBudget()
+{
+    SimulationBuilder builder;
+    builder.setConfig(makeStressConfig(100, 8500, 60));
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const auto start = std::chrono::steady_clock::now();
+
+    for (size_t i = 0; i < 1000; ++i) {
+        test.scenario().step(20);
+
+        if (i % 100 == 0) {
+            const std::vector<uint8_t> payload = {
+                static_cast<uint8_t>(i & 0xFF),
+                static_cast<uint8_t>((i / 2) & 0xFF),
+            };
+
+            const int rc = test.sendFromDevice(kNodeBase,
+                                               payload,
+                                               Priority::NORMAL,
+                                               PropagationMode::OMNI,
+                                               0,
+                                               0,
+                                               3000,
+                                               30);
+            expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                        "budget test send should succeed");
+        }
+    }
+
+    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - start)
+                                .count();
+
+    const uint16_t probe_node = static_cast<uint16_t>(kNodeBase + 1);
+    expectTrue(test.waitForMessageCount(probe_node, 10, 5000),
+               "probe node did not receive expected budget-test messages");
+
+    expectTrue(elapsed_ms <= 8000,
+               "100-node, 1000-step workload exceeded phase-5 time budget");
+
+    test.stop();
+}
+
+int runTest(const char* name, const std::function<void()>& fn)
+{
+    try {
+        fn();
+        std::printf("[PASS] %s\n", name);
+        return 0;
+    } catch (const std::exception& ex) {
+        std::printf("[FAIL] %s: %s\n", name, ex.what());
+        return 1;
+    } catch (...) {
+        std::printf("[FAIL] %s: unknown exception\n", name);
+        return 1;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    int failures = 0;
+
+    failures += runTest("large_scale_broadcast_burst_no_loss", testLargeScaleBroadcastBurstNoLoss);
+    failures += runTest("repeatability_snapshot_stable_across_runs",
+                        testRepeatabilitySnapshotStableAcrossRuns);
+    failures += runTest("hundred_node_step_budget", testHundredNodeStepBudget);
+
+    if (failures == 0) {
+        std::printf("All phase 5 simulation tests passed\n");
+        return 0;
+    }
+
+    std::printf("Phase 5 simulation tests failed (%d)\n", failures);
+    return 1;
+}

--- a/simulation/tests/src/test_simulation_phase5.cpp
+++ b/simulation/tests/src/test_simulation_phase5.cpp
@@ -111,6 +111,12 @@ SimulationConfig makeStressConfig(size_t node_count,
 
 using Snapshot = std::unordered_map<uint16_t, std::array<uint64_t, 2>>;
 
+struct StochasticRunSummary {
+    uint64_t received_count{0};
+    uint64_t received_hash{0};
+    uint64_t tx_fail_per{0};
+};
+
 Snapshot captureSnapshot(const SimulationTestBase& test)
 {
     Snapshot out;
@@ -203,6 +209,198 @@ Snapshot runRepeatableWorkload()
     Snapshot snapshot = captureSnapshot(test);
     test.stop();
     return snapshot;
+}
+
+SimulationConfig makeStochasticPerConfig(uint64_t seed)
+{
+    SimulationConfig cfg;
+    cfg.runtime.carrier_freq_mhz = 868.0f;
+    cfg.runtime.start_time_s = 2200;
+    cfg.runtime.network_config = NetworkConfig{128, 8, 64};
+    cfg.runtime.compatibility_immediate_delivery = false;
+    cfg.runtime.random_seed = seed;
+    cfg.runtime.data_rate_bps = 400000;
+    cfg.runtime.slot_time_us = 1000;
+    cfg.runtime.difs_us = 0;
+    cfg.runtime.cw_min = 1;
+    cfg.runtime.cw_max = 15;
+    cfg.runtime.max_retries = 4;
+    cfg.runtime.propagation_min_delay_us = 0;
+    cfg.runtime.enable_collision_model = false;
+    cfg.runtime.enable_congestion_drops = false;
+    cfg.runtime.per_model = SimulationRuntimeConfig::PerModel::Logistic;
+    cfg.runtime.per_logistic_k = 0.9f;
+    cfg.runtime.per_logistic_mid_db = 10.0f;
+    cfg.runtime.fading_stddev_db = 1.0f;
+    cfg.runtime.noise_jitter_db = 0.5f;
+
+    cfg.devices.push_back(makeDevice(kNodeBase,
+                                     kBasePoint,
+                                     14.0f,
+                                     -120.0f,
+                                     0,
+                                     0));
+
+    // ~13.3 km north gives SNR near the logistic midpoint for meaningful randomness.
+    cfg.devices.push_back(makeDevice(static_cast<uint16_t>(kNodeBase + 1),
+                                     GeoPoint{126200000, 773000000},
+                                     14.0f,
+                                     -120.0f,
+                                     0,
+                                     0));
+    return cfg;
+}
+
+StochasticRunSummary runStochasticPerWorkload(uint64_t seed)
+{
+    SimulationBuilder builder;
+    builder.setConfig(makeStochasticPerConfig(seed));
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const uint16_t src = kNodeBase;
+    const uint16_t dst = static_cast<uint16_t>(kNodeBase + 1);
+    constexpr size_t kMessageCount = 80;
+
+    for (size_t i = 0; i < kMessageCount; ++i) {
+        const std::vector<uint8_t> payload = {
+            static_cast<uint8_t>(i & 0xFF),
+            static_cast<uint8_t>((i * 3) & 0xFF),
+            0xAA,
+            0x55,
+        };
+
+        const int rc = test.sendFromDevice(src,
+                                           payload,
+                                           Priority::NORMAL,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           60000,
+                                           60);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "stochastic PER workload send should succeed");
+        test.scenario().step(6);
+    }
+
+    test.stepUntil([]() { return false; }, 2000, 10, 1);
+
+    const std::vector<CapturedMessage> msgs = test.receivedMessages(dst);
+    uint64_t hash = 1469598103934665603ULL;
+    for (const CapturedMessage& msg : msgs) {
+        hash ^= static_cast<uint64_t>(msg.header.message_id);
+        hash *= 1099511628211ULL;
+        for (uint8_t b : msg.payload) {
+            hash ^= static_cast<uint64_t>(b);
+            hash *= 1099511628211ULL;
+        }
+    }
+
+    const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+    StochasticRunSummary summary;
+    summary.received_count = static_cast<uint64_t>(msgs.size());
+    summary.received_hash = hash;
+    summary.tx_fail_per = metrics.tx_fail_per;
+
+    test.stop();
+    return summary;
+}
+
+void testStochasticPerSameSeedIsRepeatable()
+{
+    const StochasticRunSummary first = runStochasticPerWorkload(1337);
+    const StochasticRunSummary second = runStochasticPerWorkload(1337);
+
+    expectTrue(first.received_count == second.received_count,
+               "same-seed stochastic workload should keep identical receive counts");
+    expectTrue(first.received_hash == second.received_hash,
+               "same-seed stochastic workload should keep identical receive hashes");
+    expectTrue(first.tx_fail_per == second.tx_fail_per,
+               "same-seed stochastic workload should keep identical PER-failure counters");
+}
+
+void testStochasticPerDifferentSeedsDiverge()
+{
+    const StochasticRunSummary seed_a = runStochasticPerWorkload(1001);
+    const StochasticRunSummary seed_b = runStochasticPerWorkload(2002);
+
+    const bool count_differs = seed_a.received_count != seed_b.received_count;
+    const bool hash_differs = seed_a.received_hash != seed_b.received_hash;
+    const bool per_differs = seed_a.tx_fail_per != seed_b.tx_fail_per;
+
+    expectTrue(count_differs || hash_differs || per_differs,
+               "different seeds should diverge in stochastic PER outcomes");
+}
+
+void testCongestionThresholdPreventsDropsUnderLightLoad()
+{
+    SimulationConfig cfg;
+    cfg.runtime.carrier_freq_mhz = 868.0f;
+    cfg.runtime.start_time_s = 2400;
+    cfg.runtime.network_config = NetworkConfig{128, 8, 64};
+    cfg.runtime.compatibility_immediate_delivery = false;
+    cfg.runtime.random_seed = 7;
+    cfg.runtime.data_rate_bps = 1000000;
+    cfg.runtime.slot_time_us = 1000;
+    cfg.runtime.difs_us = 0;
+    cfg.runtime.cw_min = 1;
+    cfg.runtime.cw_max = 15;
+    cfg.runtime.max_retries = 4;
+    cfg.runtime.enable_collision_model = false;
+    cfg.runtime.enable_congestion_drops = true;
+    cfg.runtime.congestion_utilization_threshold_pct = 99.0f;
+    cfg.runtime.congestion_drop_probability = 1.0f;
+    cfg.runtime.congestion_min_elapsed_us = 500000;
+    cfg.runtime.per_model = SimulationRuntimeConfig::PerModel::Disabled;
+
+    cfg.devices.push_back(makeDevice(kNodeBase, kBasePoint, 14.0f, -118.0f, 0, 0));
+    cfg.devices.push_back(makeDevice(static_cast<uint16_t>(kNodeBase + 1),
+                                     GeoPoint{125002000, 773001000},
+                                     14.0f,
+                                     -118.0f,
+                                     0,
+                                     0));
+
+    SimulationBuilder builder;
+    builder.setConfig(cfg);
+
+    SimulationTestBase test(builder.build());
+    test.start();
+
+    const uint16_t src = kNodeBase;
+    const uint16_t dst = static_cast<uint16_t>(kNodeBase + 1);
+    constexpr size_t kMessageCount = 20;
+
+    for (size_t i = 0; i < kMessageCount; ++i) {
+        const std::vector<uint8_t> payload = {
+            0xE0,
+            static_cast<uint8_t>(i & 0xFF),
+        };
+
+        const int rc = test.sendFromDevice(src,
+                                           payload,
+                                           Priority::NORMAL,
+                                           PropagationMode::OMNI,
+                                           0,
+                                           0,
+                                           5000,
+                                           30);
+        expectEqInt(rc, static_cast<int>(NetworkError::Ok),
+                    "light-load congestion test send should succeed");
+        test.scenario().step(50);
+    }
+
+    expectTrue(test.waitForMessageCount(dst, kMessageCount, 3000, 20, 1),
+               "light-load utilization should stay below threshold and avoid congestion drops");
+
+    const SimulationMetricsSnapshot metrics = test.scenario().metrics();
+    expectEqSize(test.receivedCount(dst), kMessageCount,
+                 "light-load congestion configuration should keep all deliveries");
+    expectTrue(metrics.channel_utilization_pct < 99.0,
+               "light-load utilization should remain below congestion threshold");
+
+    test.stop();
 }
 
 void testLargeScaleBroadcastBurstNoLoss()
@@ -337,6 +535,12 @@ int main()
     failures += runTest("repeatability_snapshot_stable_across_runs",
                         testRepeatabilitySnapshotStableAcrossRuns);
     failures += runTest("hundred_node_step_budget", testHundredNodeStepBudget);
+    failures += runTest("stochastic_per_same_seed_is_repeatable",
+                        testStochasticPerSameSeedIsRepeatable);
+    failures += runTest("stochastic_per_different_seeds_diverge",
+                        testStochasticPerDifferentSeedsDiverge);
+    failures += runTest("congestion_threshold_prevents_drops_under_light_load",
+                        testCongestionThresholdPreventsDropsUnderLightLoad);
 
     if (failures == 0) {
         std::printf("All phase 5 simulation tests passed\n");


### PR DESCRIPTION
Introduce a deterministic, event-driven channel/MAC foundation and runtime metrics. Adds SimulationEventQueue and SimulationMetricsCollector (headers + implementations), expands SimulatedNetwork with scheduling, delivery, collision/PER hooks, CW/backoff state, timekeeping, and a compatibility_immediate_delivery mode; new APIs include configureMac, setNowUs, processUntil, metricsSnapshot and resetMetrics. Update config parsing and SimulationRuntimeConfig with many new runtime/MAC options (random_seed, per_model, data_rate_bps, slot/difs, cw/min/max, fading/noise, propagation delay, congestion toggles). Wire new sources into CMake, add detailed design doc simulation_wireless_upgrade_design.md, and update tests to exercise the phased simulation behavior. Changes are focused on preserving backward compatibility by default while enabling future phased MAC/channel features and reproducible seeded runs.